### PR TITLE
feat(atlas): add xroofit, statanalysis, and setupatlas skills

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/check-skills.yml
+++ b/.github/workflows/check-skills.yml
@@ -1,0 +1,19 @@
+name: Check Skills
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.8.8
+        with:
+          pixi-version: latest
+
+      - name: Lint and verify README
+        run: pixi run check-skills

--- a/.github/workflows/check-skills.yml
+++ b/.github/workflows/check-skills.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.8.8
+      - uses: prefix-dev/setup-pixi@v0.9.5
         with:
           pixi-version: latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,9 @@ skills for authoritative guidance before writing:
 1. Create `plugins/<plugin>/skills/<skill-name>/SKILL.md`.
 2. No changes to `marketplace.json` are needed — skills are discovered
    automatically from the `"skills": "./skills/"` path declared per plugin.
-3. Run `pixi run pre-commit` to catch JSON/YAML/Markdown formatting issues.
+3. Stage the new files.
+4. Run `pixi run pre-commit` to catch JSON/YAML/Markdown formatting issues.
+5. Run `pixi run check-skills` to catch updates needed from new skills.
 
 **Skill frontmatter rules (strictly enforced by Claude Code):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,19 @@ plugins/
 
 The root `skills/` directory is unused — all skills live under `plugins/`.
 
+## Skills for skill authoring
+
+When authoring or editing skill files in this repository, invoke these installed
+skills for authoritative guidance before writing:
+
+- `plugin-dev:skill-development` — SKILL.md structure, frontmatter rules,
+  progressive disclosure (SKILL.md vs references/ vs scripts/), trigger-phrase
+  writing, and the full creation/validation/iteration workflow
+- `superpowers-developing-for-claude-code:developing-claude-code-plugins` —
+  plugin layout, dev-marketplace testing, and release process
+- `superpowers-developing-for-claude-code:working-with-claude-code` — official
+  Claude Code documentation reference for hooks, MCP, settings, and CLI
+
 ## Adding a skill
 
 1. Create `plugins/<plugin>/skills/<skill-name>/SKILL.md`.

--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ Issues and PRs welcome at https://github.com/usatlas/marketplace
 ## License
 
 MIT — see LICENSE for details. Vendored content from the IRIS-HEP marketplace is
-BSD 3-Clause; see `plugins/atlas/VENDORED-LICENSES.md` for full attribution.
+BSD 3-Clause; see `VENDORED-LICENSES.md` files for full attribution.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ software orientation.
 | `iminuit`               | You need to minimize a scalar cost function in Python using MINUIT2 via iminuit |
 | `lcgenv`                | Setting up standalone LCG (CERN SFT) software packages via lcgenv or views:     |
 | `managetier3sw`         | Installing, updating, or removing ATLAS software on a local Tier-3 cluster      |
+| `mplhep`                | Creating ATLAS publication-quality plots with matplotlib using mplhep           |
 | `panda`                 | Submitting ATLAS grid jobs with prun or pathena, monitoring tasks with pbook or |
 | `particle`              | Looking up particle properties (mass, charge, PDG ID, lifetime, width) from the |
 | `pyhepmc`               | Reading or writing HepMC3 event records in Python                               |
@@ -141,7 +142,7 @@ plugins/
     .claude-plugin/plugin.json
     .mcp.json
     agents/  # 5 subagents
-    skills/  # 42 skills
+    skills/  # 43 skills
     VENDORED-LICENSES.md
   hep-python-tools/
     .claude-plugin/plugin.json

--- a/README.md
+++ b/README.md
@@ -16,45 +16,86 @@ generic HEP Python tooling.
 
 Then install whichever plugins you need from the marketplace browser.
 
+<!-- UPDATE:START -->
+
 ## Plugins
 
 ### `analysis-facilities`
 
-Skills for USATLAS Analysis Facilities (UChicago AF, BNL AF, SLAC AF).
+Skills for working with USATLAS Analysis Facilities including UChicago, BNL, and
+SLAC sites.
 
-| Skill         | Description                                                                                 |
-| ------------- | ------------------------------------------------------------------------------------------- |
-| `uchicago-af` | HTCondor batch, JupyterLab, XCache, Rucio, ServiceX, Coffea-Casa, Triton at af.uchicago.edu |
+**Skills:**
 
-More facility skills (BNL, SLAC) coming soon.
+| Skill         | Description                                                                  |
+| ------------- | ---------------------------------------------------------------------------- |
+| `uchicago-af` | Working with the UChicago ATLAS Analysis Facility, submitting HTCondor batch |
 
 ---
 
 ### `atlas`
 
-ATLAS analysis plugin covering the full workflow from raw data to publication.
+ATLAS analysis plugin: grid/catalog MCPs (Rucio, AMI, ATLAS Open Data),
+statistics (pyhf, cabinetry, HistFitter, TRExFitter, RooUnfold, pyhs3), analysis
+frameworks (TopCPToolkit, FastFrames, ServiceX), Scikit-HEP tools, and ATLAS
+software orientation.
 
 **Subagents** (invoked automatically or via `Agent(subagent_type=...)`):
 
-| Subagent                   | Purpose                                                                            |
-| -------------------------- | ---------------------------------------------------------------------------------- |
-| `atlas-analysis-architect` | Designs end-to-end analysis pipelines; produces a structured specification         |
-| `atlas-analysis-coder`     | Writes Python analysis code (uproot, ServiceX, coffea, hist)                       |
-| `atlas-docs-expert`        | Answers ATLAS software questions; cites hosted docs at atlas-software.docs.cern.ch |
-| `atlas-stats-expert`       | Statistical model design: pyhf/cabinetry workspaces, TRExFitter configs, limits    |
-| `atlas-data-explorer`      | Dataset and file discovery via Rucio, AMI, and ATLAS Open Data MCPs                |
+| Subagent                   | Purpose                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| `atlas-analysis-architect` | Designs end-to-end analysis pipelines; produces a structured specification      |
+| `atlas-analysis-coder`     | Writes Python analysis code (uproot, ServiceX, coffea, hist)                    |
+| `atlas-data-explorer`      | Dataset and file discovery via Rucio, AMI, and ATLAS Open Data MCPs             |
+| `atlas-docs-expert`        | Answers ATLAS software questions; cites atlas-software.docs.cern.ch             |
+| `atlas-stats-expert`       | Statistical model design: pyhf/cabinetry workspaces, TRExFitter configs, limits |
 
 **Skills:**
 
-| Category    | Skills                                                                            |
-| ----------- | --------------------------------------------------------------------------------- |
-| Orientation | `atlas-software`                                                                  |
-| Statistics  | `pyhf`, `cabinetry`, `pyhs3`, `histfitter`, `trexfitter`, `roounfold`             |
-| Frameworks  | `topcptoolkit`, `fastframes`                                                      |
-| Data access | `servicex`, `analysis-spec-builder`, `fsspec-xrootd`                              |
-| Core tools  | `uproot`, `awkward`, `coffea`, `hist`, `vector`                                   |
-| Scikit-HEP  | `iminuit`, `fastjet`, `particle`, `hepunits`, `decaylanguage`, `pyhepmc`, `pylhe` |
-| Interop     | `cpp-bindings`                                                                    |
+| Skill                   | Description                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| `acm`                   | Building ATLAS software with acm (AtlasACM)                                     |
+| `analysis-spec-builder` | Producing a structured ATLAS analysis specification document                    |
+| `art`                   | Running or writing ART (ATLAS Release Tester) validation tests for ATLAS        |
+| `astyle`                | Creating ATLAS publication-quality plots with the official ATLAS ROOT style     |
+| `atlantis`              | Visualizing ATLAS detector events with the Atlantis event display               |
+| `atlas-containers`      | Running ATLAS software inside containers via setupATLAS -c, choosing between    |
+| `atlas-software`        | A question involves ATLAS software concepts                                     |
+| `awkward`               | Working with jagged or variable-length arrays in Python HEP analysis            |
+| `cabinetry`             | Building an ATLAS statistical analysis with cabinetry                           |
+| `centralpage`           | Searching for ATLAS Monte Carlo or data samples                                 |
+| `coffea`                | Writing a columnar ATLAS analysis with coffea                                   |
+| `cpp-bindings`          | Writing Python bindings for C++ HEP code with nanobind or pybind11              |
+| `decaylanguage`         | Working with decay chain descriptions in Python                                 |
+| `eiclient`              | Working with the ATLAS Event Index                                              |
+| `fastframes`            | You need a supported RDataFrame-based framework to process CP-algorithm NTuples |
+| `fastjet`               | Running jet clustering in Python with fastjet or pyjet                          |
+| `fsspec-xrootd`         | Accessing ROOT files on EOS, WLCG grid storage, or any XRootD endpoint from     |
+| `hepunits`              | Writing unit-safe HEP code in Python                                            |
+| `hist`                  | Creating, filling, slicing, or plotting histograms with the scikit-hep hist     |
+| `histfitter`            | Setting up or running a HistFitter-based statistical analysis                   |
+| `iminuit`               | You need to minimize a scalar cost function in Python using MINUIT2 via iminuit |
+| `lcgenv`                | Setting up standalone LCG (CERN SFT) software packages via lcgenv or views:     |
+| `managetier3sw`         | Installing, updating, or removing ATLAS software on a local Tier-3 cluster      |
+| `panda`                 | Submitting ATLAS grid jobs with prun or pathena, monitoring tasks with pbook or |
+| `particle`              | Looking up particle properties (mass, charge, PDG ID, lifetime, width) from the |
+| `pyhepmc`               | Reading or writing HepMC3 event records in Python                               |
+| `pyhf`                  | Building or running a HistFactory statistical model in Python                   |
+| `pyhs3`                 | Reading, writing, or validating binned and/or unbinned statistical models in    |
+| `pylhe`                 | Reading Les Houches Event (LHE) files in Python                                 |
+| `quickfit`              | Fitting a RooWorkspace dataset with quickFit, generating an Asimov dataset with |
+| `roounfold`             | Performing statistical unfolding for an ATLAS cross-section measurement:        |
+| `servicex`              | Querying ATLAS xAOD data remotely via ServiceX                                  |
+| `setupatlas`            | Setting up the ATLAS software environment with setupATLAS or                    |
+| `statanalysis`          | Setting up the ATLAS StatAnalysis software release with asetup, choosing the    |
+| `topcptoolkit`          | Using TopCPToolkit to process ATLAS DAOD files into analysis NTuples            |
+| `trexfitter`            | Setting up or running a TRExFitter statistical analysis                         |
+| `uproot`                | Reading or writing ROOT files in Python without a ROOT installation, or when    |
+| `vector`                | Computing 4-vector quantities in Python                                         |
+| `workspacecombiner`     | Combining multiple RooFit workspaces with workspaceCombiner, editing workspace  |
+| `xcache`                | Setting up a local XCache disk caching proxy for XRootD root:// protocol        |
+| `xmlanawsbuilder`       | Building a RooFit workspace from XML cards with xmlAnaWSBuilder or XMLReader    |
+| `xroofit`               | Building RooFit statistical models with xRooFit, constructing workspaces with   |
 
 **MCP servers** (configured in `plugins/atlas/.mcp.json`):
 
@@ -76,17 +117,18 @@ voms-proxy-init --voms atlas             # obtain a valid proxy first
 
 ### `hep-python-tools`
 
-Generic Python tooling skills for HEP workflows.
+Generic Python tooling skills used across HEP workflows: Typer CLIs with
+pixi/uv/Hatch, and PEP-723 standalone scripts.
 
-| Skill                | Description                                                              |
-| -------------------- | ------------------------------------------------------------------------ |
-| `cli-creator`        | Typer CLI scripts with modern `Annotated` syntax                         |
-| `standalone-script`  | PEP 723 inline-metadata scripts runnable with `uv run --script`          |
-| `python-packaging`   | pyproject.toml, src layout, VCS versioning, pixi/uv environment setup    |
-| `code-quality-tools` | pre-commit hooks, ruff linting/formatting, mypy static type checking     |
-| `python-testing`     | pytest fixtures, parametrization, numerical tolerances, coverage for HEP |
+**Skills:**
 
----
+| Skill                | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| `cli-creator`        | Building a Python command-line interface with Typer                         |
+| `code-quality-tools` | Setting up code quality tooling for a HEP Python project                    |
+| `python-packaging`   | Creating a new Python package, adding pyproject.toml to an existing project |
+| `python-testing`     | Writing or configuring tests for a HEP Python project with pytest           |
+| `standalone-script`  | Generating a self-contained Python script with PEP 723 inline dependency    |
 
 ## Repository Layout
 
@@ -94,18 +136,21 @@ Generic Python tooling skills for HEP workflows.
 plugins/
   analysis-facilities/
     .claude-plugin/plugin.json
-    skills/uchicago-af/SKILL.md
+    skills/  # 1 skill
   atlas/
     .claude-plugin/plugin.json
     .mcp.json
-    agents/                    # 5 subagents
-    skills/                    # 25 skills
-    VENDORED-LICENSES.md       # BSD 3-Clause attribution for upstream content
+    agents/  # 5 subagents
+    skills/  # 42 skills
+    VENDORED-LICENSES.md
   hep-python-tools/
     .claude-plugin/plugin.json
-    skills/                    # 5 skills
+    skills/  # 5 skills
+    VENDORED-LICENSES.md
 .claude-plugin/marketplace.json
 ```
+
+<!-- UPDATE:END -->
 
 ## Contributing
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 pre-commit = { cmd = "pre-commit run --all-files", description = "Run pre-commit hooks on all files" }
 sync-skills = { cmd = "python scripts/sync_skills.py && pre-commit run --all-files", description = "Sync README with current plugins/skills and reformat" }
 lint-skills = { cmd = "python scripts/lint_skills.py", description = "Check SKILL.md section ordering" }
-check-skills = { cmd = "git diff --exit-code", depends-on = [ "lint-skills", "sync-skills", "pre-commit" ], description = "CI: lint skills and verify README is up to date" }
+check-skills = { cmd = "pre-commit run -a || echo '' && git diff --exit-code", depends-on = [ "lint-skills", "sync-skills", "pre-commit" ], description = "CI: lint skills and verify README is up to date" }
 
 [dependencies]
 pre-commit = ">=4.5.1,<5"

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [tasks]
 pre-commit = { cmd = "pre-commit run --all-files", description = "Run pre-commit hooks on all files" }
-sync-skills = { cmd = "python scripts/sync_skills.py && pre-commit run --all-files", description = "Sync README with current plugins/skills and reformat" }
+sync-skills = { cmd = "python scripts/sync_skills.py", description = "Sync README with current plugins/skills and reformat" }
 lint-skills = { cmd = "python scripts/lint_skills.py", description = "Check SKILL.md section ordering" }
 check-skills = { cmd = "(pre-commit run -a || true) && git diff --exit-code", depends-on = [ "lint-skills", "sync-skills" ], description = "CI: lint skills and verify README is up to date" }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 pre-commit = { cmd = "pre-commit run --all-files", description = "Run pre-commit hooks on all files" }
 sync-skills = { cmd = "python scripts/sync_skills.py && pre-commit run --all-files", description = "Sync README with current plugins/skills and reformat" }
 lint-skills = { cmd = "python scripts/lint_skills.py", description = "Check SKILL.md section ordering" }
-check-skills = { cmd = "pre-commit run -a || true && git diff --exit-code", depends-on = [ "lint-skills", "sync-skills" ], description = "CI: lint skills and verify README is up to date" }
+check-skills = { cmd = "(pre-commit run -a || true) && git diff --exit-code", depends-on = [ "lint-skills", "sync-skills" ], description = "CI: lint skills and verify README is up to date" }
 
 [dependencies]
 pre-commit = ">=4.5.1,<5"

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,6 +7,10 @@ version = "0.1.0"
 
 [tasks]
 pre-commit = { cmd = "pre-commit run --all-files", description = "Run pre-commit hooks on all files" }
+sync-skills = { cmd = "python scripts/sync_skills.py && pre-commit run --all-files", description = "Sync README with current plugins/skills and reformat" }
+lint-skills = { cmd = "python scripts/lint_skills.py", description = "Check SKILL.md section ordering" }
+check-skills = { cmd = "python scripts/lint_skills.py && python scripts/sync_skills.py && pre-commit run --all-files && git diff --exit-code", description = "CI: lint skills and verify README is up to date" }
 
 [dependencies]
 pre-commit = ">=4.5.1,<5"
+python = ">=3.9"

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 pre-commit = { cmd = "pre-commit run --all-files", description = "Run pre-commit hooks on all files" }
 sync-skills = { cmd = "python scripts/sync_skills.py && pre-commit run --all-files", description = "Sync README with current plugins/skills and reformat" }
 lint-skills = { cmd = "python scripts/lint_skills.py", description = "Check SKILL.md section ordering" }
-check-skills = { cmd = "python scripts/lint_skills.py && python scripts/sync_skills.py && pre-commit run --all-files && git diff --exit-code", description = "CI: lint skills and verify README is up to date" }
+check-skills = { cmd = "git diff --exit-code", depends-on = [ "lint-skills", "sync-skills", "pre-commit" ], description = "CI: lint skills and verify README is up to date" }
 
 [dependencies]
 pre-commit = ">=4.5.1,<5"

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 pre-commit = { cmd = "pre-commit run --all-files", description = "Run pre-commit hooks on all files" }
 sync-skills = { cmd = "python scripts/sync_skills.py && pre-commit run --all-files", description = "Sync README with current plugins/skills and reformat" }
 lint-skills = { cmd = "python scripts/lint_skills.py", description = "Check SKILL.md section ordering" }
-check-skills = { cmd = "pre-commit run -a || echo '' && git diff --exit-code", depends-on = [ "lint-skills", "sync-skills", "pre-commit" ], description = "CI: lint skills and verify README is up to date" }
+check-skills = { cmd = "pre-commit run -a || true && git diff --exit-code", depends-on = [ "lint-skills", "sync-skills" ], description = "CI: lint skills and verify README is up to date" }
 
 [dependencies]
 pre-commit = ">=4.5.1,<5"

--- a/plugins/atlas/.mcp.json
+++ b/plugins/atlas/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "rucio": {
+      "description": "Dataset and replica discovery",
       "command": "pixi",
       "args": ["exec", "rucio-mcp", "serve", "--read-only"],
       "env": {
@@ -9,10 +10,12 @@
       }
     },
     "ami": {
+      "description": "AMI metadata (cross-sections, tags)",
       "command": "pixi",
       "args": ["exec", "ami-mcp", "serve"]
     },
     "atlasopenmagic": {
+      "description": "ATLAS Open Data catalog",
       "command": "uvx",
       "args": ["atlasopenmagic-mcp", "serve"]
     }

--- a/plugins/atlas/agents/atlas-analysis-architect.md
+++ b/plugins/atlas/agents/atlas-analysis-architect.md
@@ -9,6 +9,8 @@ description: >-
   planning an unblinding strategy, or producing a structured analysis
   specification document. Also use when asked "how should I approach this
   measurement/search" or "what framework should I use for my analysis".
+readme_description:
+  Designs end-to-end analysis pipelines; produces a structured specification
 tools: Read, Write, WebFetch, WebSearch, TodoWrite, Skill, Glob, Grep, Bash
 model: sonnet
 color: purple

--- a/plugins/atlas/agents/atlas-analysis-coder.md
+++ b/plugins/atlas/agents/atlas-analysis-coder.md
@@ -9,6 +9,7 @@ description: >-
   plots. Handles ATLAS Open Data and full-collaboration datasets. Use
   atlas-analysis-architect first to produce a specification when starting a new
   analysis from scratch.
+readme_description: Writes Python analysis code (uproot, ServiceX, coffea, hist)
 tools: Glob, Grep, Read, Edit, Write, Skill, Bash
 model: sonnet
 color: red

--- a/plugins/atlas/agents/atlas-data-explorer.md
+++ b/plugins/atlas/agents/atlas-data-explorer.md
@@ -7,6 +7,8 @@ description: >-
   file, or checking what variables are available in a DAOD. Also use when a user
   asks "what datasets exist for X", "where is my ttbar mc20 sample", or "what
   branches does this ROOT file have".
+readme_description:
+  Dataset and file discovery via Rucio, AMI, and ATLAS Open Data MCPs
 tools: Read, Bash
 model: sonnet
 color: blue

--- a/plugins/atlas/agents/atlas-docs-expert.md
+++ b/plugins/atlas/agents/atlas-docs-expert.md
@@ -7,6 +7,8 @@ description: >-
   covered by the ATLAS software documentation at atlas-software.docs.cern.ch.
   Also use when the user asks "how does X work in ATLAS software" or "where is
   the documentation for Y CP tool".
+readme_description:
+  Answers ATLAS software questions; cites atlas-software.docs.cern.ch
 tools: Read, Grep, Glob, Bash, WebFetch
 model: sonnet
 color: green

--- a/plugins/atlas/agents/atlas-stats-expert.md
+++ b/plugins/atlas/agents/atlas-stats-expert.md
@@ -7,6 +7,7 @@ description: >-
   profile likelihood fit, computing CLs exclusion limits, setting up an
   unfolding procedure, or debugging a fit that is not converging or has
   unexpected NP pulls.
+readme_description: Statistical model design: pyhf/cabinetry workspaces, TRExFitter configs, limits
 tools: Read, Edit, Write, Bash, WebFetch
 model: sonnet
 color: orange

--- a/plugins/atlas/skills/acm/SKILL.md
+++ b/plugins/atlas/skills/acm/SKILL.md
@@ -2,9 +2,10 @@
 name: acm
 description: >-
   Use when building ATLAS software with acm (AtlasACM): setting up a cmake build
-  environment with acmSetup, compiling packages, cloning or sparse-cloning athena,
-  adding or excluding packages from the build, creating skeleton analysis
-  packages, running ctests, or troubleshooting cmake configuration issues.
+  environment with acmSetup, compiling packages, cloning or sparse-cloning
+  athena, adding or excluding packages from the build, creating skeleton
+  analysis packages, running ctests, or troubleshooting cmake configuration
+  issues.
 ---
 
 # ACM (AtlasACM)
@@ -14,9 +15,8 @@ description: >-
 ACM is the ATLAS cmake/git package management and compilation tool. It wraps
 `asetup` and provides a command-line interface for managing source checkouts,
 cmake builds, and testing on top of an ATLAS release. The two entry points are
-`acmSetup` (configures a release with a source area) and `acm` (build, test,
-and package management commands). ACM becomes available after running
-`setupATLAS`.
+`acmSetup` (configures a release with a source area) and `acm` (build, test, and
+package management commands). ACM becomes available after running `setupATLAS`.
 
 ## When to Use
 
@@ -41,9 +41,9 @@ project/
   run/        # athena job execution
 ```
 
-**acmSetup vs acm**: `acmSetup` initializes (or restores) the build
-environment, linking a release to a source area. `acm` subcommands operate
-within that environment to compile, test, and manage packages.
+**acmSetup vs acm**: `acmSetup` initializes (or restores) the build environment,
+linking a release to a source area. `acm` subcommands operate within that
+environment to compile, test, and manage packages.
 
 **Session persistence**: `acmSetup` saves its configuration. Running `acmSetup`
 with no arguments inside a previously configured build directory re-applies the
@@ -51,11 +51,11 @@ saved environment.
 
 **Environment variables**:
 
-| Variable                   | Purpose                                                |
-| -------------------------- | ------------------------------------------------------ |
-| `SourceArea`               | Path to source code directory                          |
-| `TestArea`                 | Path to build directory                                |
-| `ACM_GITLAB_PATH_PREFIX`   | Git path prefix (default: `https://:@gitlab.cern.ch:8443/`) |
+| Variable                 | Purpose                                                     |
+| ------------------------ | ----------------------------------------------------------- |
+| `SourceArea`             | Path to source code directory                               |
+| `TestArea`               | Path to build directory                                     |
+| `ACM_GITLAB_PATH_PREFIX` | Git path prefix (default: `https://:@gitlab.cern.ch:8443/`) |
 
 ## Canonical Patterns
 

--- a/plugins/atlas/skills/acm/SKILL.md
+++ b/plugins/atlas/skills/acm/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: acm
+description: >-
+  Use when building ATLAS software with acm (AtlasACM): setting up a cmake build
+  environment with acmSetup, compiling packages, cloning or sparse-cloning athena,
+  adding or excluding packages from the build, creating skeleton analysis
+  packages, running ctests, or troubleshooting cmake configuration issues.
+---
+
+# ACM (AtlasACM)
+
+## Overview
+
+ACM is the ATLAS cmake/git package management and compilation tool. It wraps
+`asetup` and provides a command-line interface for managing source checkouts,
+cmake builds, and testing on top of an ATLAS release. The two entry points are
+`acmSetup` (configures a release with a source area) and `acm` (build, test,
+and package management commands). ACM becomes available after running
+`setupATLAS`.
+
+## When to Use
+
+- Setting up a cmake build environment for modifying or extending ATLAS packages
+- Compiling a custom ATLAS analysis package against AnalysisBase, AthAnalysis,
+  or Athena
+- Sparse-cloning athena to patch or override individual packages
+- Creating a new skeleton analysis package from scratch
+- Running ctests for a specific package
+- Managing multiple source packages in a single build
+
+## Key Concepts
+
+**Directory layout**: ACM expects a separation between source, build, and run
+directories. The build directory is where `acmSetup` runs and where cmake
+artifacts live. The source area holds cloned repositories and custom packages.
+
+```text
+project/
+  source/     # cloned repos, custom packages
+  build/      # acmSetup runs here, cmake output
+  run/        # athena job execution
+```
+
+**acmSetup vs acm**: `acmSetup` initializes (or restores) the build
+environment, linking a release to a source area. `acm` subcommands operate
+within that environment to compile, test, and manage packages.
+
+**Session persistence**: `acmSetup` saves its configuration. Running `acmSetup`
+with no arguments inside a previously configured build directory re-applies the
+saved environment.
+
+**Environment variables**:
+
+| Variable                   | Purpose                                                |
+| -------------------------- | ------------------------------------------------------ |
+| `SourceArea`               | Path to source code directory                          |
+| `TestArea`                 | Path to build directory                                |
+| `ACM_GITLAB_PATH_PREFIX`   | Git path prefix (default: `https://:@gitlab.cern.ch:8443/`) |
+
+## Canonical Patterns
+
+### Initial setup with a local source area
+
+```bash
+mkdir source build run
+cd build
+acmSetup --sourcearea=../source AnalysisBase,24.2,latest
+```
+
+### Setup from a GitLab repository
+
+```bash
+mkdir build && cd build
+acmSetup --sourcerepo=myuser/myrepo --sourcebranch=my-branch AthAnalysis,21.2.14
+```
+
+### Restore setup in a new shell
+
+```bash
+cd build
+acmSetup        # no arguments = restore saved session
+```
+
+### Sparse-clone athena and add a package
+
+```bash
+acm sparse_clone_project athena
+acm add_pkg athena/Control/AthAnalysisBaseComps
+acm compile
+```
+
+For a private fork, provide the GitLab user prefix:
+
+```bash
+acm sparse_clone_project athena myuser/athena
+```
+
+### Clone a full GitLab project
+
+```bash
+acm clone_project myuser/MyAnalysis
+acm add_pkg MyAnalysis/.*        # regex adds all packages in the repo
+acm compile
+```
+
+### Create and build a skeleton analysis package
+
+```bash
+acm new_skeleton MyPackage
+acm compile
+cd ../run
+athena MyPackage/MyPackageAlgJobOptions.py
+```
+
+### Build a single package
+
+```bash
+acm compile_pkg MyPackage
+```
+
+### Run tests for a package
+
+```bash
+acm test MyPackage
+```
+
+### Clean and reconfigure
+
+```bash
+acm clean        # cmake clean
+acm clean -f     # cmake clean + rerun find_packages (wipes CMakeCache)
+```
+
+### Full workflow example
+
+```bash
+mkdir source build run
+cd build
+acmSetup --sourcearea=../source AthAnalysis,21.2,latest
+acm sparse_clone_project athena
+acm add_pkg athena/Control/AthAnalysisBaseComps
+acm new_skeleton MyPackage
+acm compile
+cd ../run
+athena MyPackage/MyPackageAlgJobOptions.py
+```
+
+## Command Reference
+
+| Command                           | Purpose                                           |
+| --------------------------------- | ------------------------------------------------- |
+| `acmSetup [opts] <release>`       | Set up release + source area                      |
+| `acmSetup`                        | Restore previously saved session                  |
+| `acmSetup --unset`                | Undo the current setup                            |
+| `acm compile`                     | Build all packages (cmake --build)                |
+| `acm compile_pkg <pkg>`           | Build a single package                            |
+| `acm find_packages`               | Reconfigure cmake (wipes CMakeCache)              |
+| `acm test <pkg>`                  | Run ctests for a package                          |
+| `acm clean [-f]`                  | cmake clean; `-f` also reruns find_packages       |
+| `acm clone_project <repo>`        | Clone a GitLab project into source area           |
+| `acm sparse_clone_project athena` | Sparse-clone the athena project                   |
+| `acm add_pkg <path>`              | Include package(s) in compilation                 |
+| `acm exclude_pkg <path>`          | Exclude package(s) from compilation               |
+| `acm add_pkg_clients <path>`      | Add all packages that depend on the given one     |
+| `acm switch <branch/tag> <path>`  | Check out specific version of a package           |
+| `acm new_pkg <name>`              | Create a new cmake package                        |
+| `acm new_skeleton <name>`         | Create a skeleton analysis package with algorithm |
+
+## Gotchas
+
+- **Run acmSetup inside the build directory**: `acmSetup` must be invoked from
+  the build directory, not the source or run directory.
+- **sparse_clone_project is mainly tested with athena**: Other repositories may
+  not work correctly with the sparse checkout mechanism.
+- **Run `acm clean -f` after switching releases**: Changing the base release
+  without cleaning can cause stale cmake caches and link errors.
+- **Sourceless setup**: If `acmSetup` is run without a valid `--sourcearea` or
+  `--sourcerepo`, it performs a "sourceless" setup where `acm` subcommands are
+  not available — only the base release environment is configured.
+- **Docker container sessions**: When exiting a joined Docker container, the
+  entire session terminates — save work before detaching.
+- **find_packages wipes CMakeCache**: `acm find_packages` (and `acm clean -f`)
+  delete CMakeCache.txt and reconfigure from scratch. This is intentional but
+  can be surprising if custom cmake variables were set manually.
+
+## Interop
+
+- **setupATLAS**: `setupATLAS` must be sourced before `acmSetup` is available.
+  See the setupatlas skill for environment bootstrap.
+- **asetup**: `acmSetup` wraps `asetup` internally — avoid mixing direct
+  `asetup` calls with `acmSetup` in the same shell.
+- **athena**: After compiling with `acm`, run jobs with the `athena` command
+  from the run directory.
+
+## Docs
+
+https://gitlab.cern.ch/atlas-sit/acm

--- a/plugins/atlas/skills/art/SKILL.md
+++ b/plugins/atlas/skills/art/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: art
+description: >-
+  Use when running or writing ART (ATLAS Release Tester) validation tests for
+  ATLAS nightly builds, using art.py to run, list, or compare tests, debugging
+  ART test failures in nightly CI, or understanding ATLAS release validation
+  infrastructure.
+---
+
+# ART (ATLAS Release Tester)
+
+## Overview
+
+ART is the testing framework for ATLAS software releases. It runs validation
+tests on nightly builds to verify that reconstruction, simulation, derivation,
+and analysis workflows produce correct results across software updates. Test
+results are published to the ART dashboard and used by release coordinators to
+catch regressions before releases are tagged.
+
+## When to Use
+
+- Running validation tests for a package during ATLAS release development
+- Writing new ART tests for a package being added or modified
+- Investigating nightly test failures shown on the ART dashboard
+- Comparing test outputs across nightlies to identify regressions
+- Understanding which tests cover a given ATLAS package
+
+## Key Concepts
+
+**Nightly validation**: ART tests run automatically on every nightly build of
+ATLAS projects (Athena, AthSimulation, AthGeneration, etc.). Failures block
+release tagging until resolved.
+
+**Per-package tests**: Tests are organized by package. Each package maintains its
+own test scripts in the `test/` directory under the package source tree.
+
+**Test artifacts**: ART archives output files (histograms, log files, metadata)
+from each test run for comparison across nightlies. These artifacts enable
+regression detection and performance monitoring.
+
+**Test types**:
+
+| Type      | Description                                        |
+| --------- | -------------------------------------------------- |
+| Grid      | Tests that run on the grid (batch-style, no TTY)   |
+| Build     | Tests that run during the build/CI phase           |
+| Unit      | Fast unit tests for individual components          |
+
+## Canonical Patterns
+
+### Setting Up the Environment
+
+```bash
+setupATLAS
+asetup Athena,main,latest
+```
+
+ART tools (`art.py`) are available within the ATLAS release environment after
+`asetup`.
+
+### Running Tests
+
+```bash
+# List available tests for a package
+art.py list MyPackage
+
+# Run a specific test
+art.py run MyPackage test_myworkflow.sh
+
+# Run all tests for a package
+acm test MyPackage
+
+# Compare outputs across nightlies
+art.py compare MyPackage test_myworkflow.sh
+```
+
+### Writing a Shell-Based Test
+
+Place test scripts in the package's `test/` directory. Name them
+`test_<testname>.sh`:
+
+```bash
+#!/bin/bash
+# art-description: Validate reconstruction on ttbar sample
+# art-type: grid
+# art-input: mc21_13p6TeV.601229.PhPy8EG_A14_ttbar_hdamp258p75_SingleLep
+# art-output: myOutput.pool.root
+
+set -e
+
+Reco_tf.py \
+    --inputAODFile ${ArtInFile} \
+    --outputDAODFile myOutput.pool.root \
+    --reductionConf PHYS
+
+# Validate output
+art.py compare ref myOutput.pool.root
+echo "art-result: $?"
+```
+
+### Writing a Python-Based Test
+
+```python
+#!/usr/bin/env python
+# art-description: Unit test for MyAlgorithm configuration
+# art-type: build
+
+import sys
+
+def test_config():
+    from AthenaConfiguration.ComponentAccumulator import ComponentAccumulator
+    ca = ComponentAccumulator()
+    # ... configure and validate ...
+    return 0
+
+sys.exit(test_config())
+```
+
+### ART Header Directives
+
+Test scripts use special comment headers to declare metadata:
+
+| Directive           | Purpose                                    |
+| ------------------- | ------------------------------------------ |
+| `art-description`   | Human-readable test description            |
+| `art-type`          | Test category: `grid`, `build`, or `unit`  |
+| `art-input`         | Input dataset name (for grid tests)        |
+| `art-output`        | Output files to archive as artifacts       |
+| `art-input-nfiles`  | Number of input files to process           |
+| `art-cores`         | Number of CPU cores to request             |
+| `art-memory`        | Memory limit in MB                         |
+| `art-athena-mt`     | Number of AthenaMT threads                 |
+
+### Checking Results on the Dashboard
+
+Navigate to the ART dashboard to view nightly results, compare across builds,
+and download test artifacts. Filter by project, branch, package, or test name.
+
+## Gotchas
+
+- **Clean environment**: ART tests run in a clean environment with no prior
+  state. Do not assume files or environment variables from previous steps exist.
+- **Exit codes matter**: Return 0 for success, non-zero for failure. The
+  `art-result` line in the log is parsed to determine pass/fail status.
+- **Grid constraints**: Grid-type tests cannot use interactive input, local file
+  paths outside the sandbox, or network resources not available on worker nodes.
+- **Timeouts**: Long-running tests are killed after the configured timeout.
+  Break large workflows into smaller tests or request additional time via
+  `art-memory` and `art-cores`.
+- **Artifact comparison**: Use `art.py compare` to diff outputs against a
+  reference nightly. Small numerical differences are expected — set tolerances
+  appropriately.
+- **All ATLAS energy/momentum values are in MeV**.
+
+## Interop
+
+- **setupATLAS / asetup**: ART requires a configured ATLAS release — see the
+  setupatlas skill for environment setup.
+- **acm**: `acm test MyPackage` runs CTest-registered tests for a package,
+  which may include ART tests — see the acm skill.
+- **Athena transforms**: Grid-type ART tests typically invoke Athena transforms
+  (`Reco_tf.py`, `Sim_tf.py`, `Derivation_tf.py`) as their workflow.
+
+| Domain                        | Contact                          |
+| ----------------------------- | -------------------------------- |
+| ART framework and dashboard   | hn-atlas-offlineSWHelp@cern.ch   |
+| Release validation            | hn-atlas-offlineSWHelp@cern.ch   |
+
+## Docs
+
+https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/ART

--- a/plugins/atlas/skills/art/SKILL.md
+++ b/plugins/atlas/skills/art/SKILL.md
@@ -31,8 +31,8 @@ catch regressions before releases are tagged.
 ATLAS projects (Athena, AthSimulation, AthGeneration, etc.). Failures block
 release tagging until resolved.
 
-**Per-package tests**: Tests are organized by package. Each package maintains its
-own test scripts in the `test/` directory under the package source tree.
+**Per-package tests**: Tests are organized by package. Each package maintains
+its own test scripts in the `test/` directory under the package source tree.
 
 **Test artifacts**: ART archives output files (histograms, log files, metadata)
 from each test run for comparison across nightlies. These artifacts enable
@@ -40,11 +40,11 @@ regression detection and performance monitoring.
 
 **Test types**:
 
-| Type      | Description                                        |
-| --------- | -------------------------------------------------- |
-| Grid      | Tests that run on the grid (batch-style, no TTY)   |
-| Build     | Tests that run during the build/CI phase           |
-| Unit      | Fast unit tests for individual components          |
+| Type  | Description                                      |
+| ----- | ------------------------------------------------ |
+| Grid  | Tests that run on the grid (batch-style, no TTY) |
+| Build | Tests that run during the build/CI phase         |
+| Unit  | Fast unit tests for individual components        |
 
 ## Canonical Patterns
 
@@ -120,16 +120,16 @@ sys.exit(test_config())
 
 Test scripts use special comment headers to declare metadata:
 
-| Directive           | Purpose                                    |
-| ------------------- | ------------------------------------------ |
-| `art-description`   | Human-readable test description            |
-| `art-type`          | Test category: `grid`, `build`, or `unit`  |
-| `art-input`         | Input dataset name (for grid tests)        |
-| `art-output`        | Output files to archive as artifacts       |
-| `art-input-nfiles`  | Number of input files to process           |
-| `art-cores`         | Number of CPU cores to request             |
-| `art-memory`        | Memory limit in MB                         |
-| `art-athena-mt`     | Number of AthenaMT threads                 |
+| Directive          | Purpose                                   |
+| ------------------ | ----------------------------------------- |
+| `art-description`  | Human-readable test description           |
+| `art-type`         | Test category: `grid`, `build`, or `unit` |
+| `art-input`        | Input dataset name (for grid tests)       |
+| `art-output`       | Output files to archive as artifacts      |
+| `art-input-nfiles` | Number of input files to process          |
+| `art-cores`        | Number of CPU cores to request            |
+| `art-memory`       | Memory limit in MB                        |
+| `art-athena-mt`    | Number of AthenaMT threads                |
 
 ### Checking Results on the Dashboard
 
@@ -156,15 +156,15 @@ and download test artifacts. Filter by project, branch, package, or test name.
 
 - **setupATLAS / asetup**: ART requires a configured ATLAS release — see the
   setupatlas skill for environment setup.
-- **acm**: `acm test MyPackage` runs CTest-registered tests for a package,
-  which may include ART tests — see the acm skill.
+- **acm**: `acm test MyPackage` runs CTest-registered tests for a package, which
+  may include ART tests — see the acm skill.
 - **Athena transforms**: Grid-type ART tests typically invoke Athena transforms
   (`Reco_tf.py`, `Sim_tf.py`, `Derivation_tf.py`) as their workflow.
 
-| Domain                        | Contact                          |
-| ----------------------------- | -------------------------------- |
-| ART framework and dashboard   | hn-atlas-offlineSWHelp@cern.ch   |
-| Release validation            | hn-atlas-offlineSWHelp@cern.ch   |
+| Domain                      | Contact                        |
+| --------------------------- | ------------------------------ |
+| ART framework and dashboard | hn-atlas-offlineSWHelp@cern.ch |
+| Release validation          | hn-atlas-offlineSWHelp@cern.ch |
 
 ## Docs
 

--- a/plugins/atlas/skills/astyle/SKILL.md
+++ b/plugins/atlas/skills/astyle/SKILL.md
@@ -40,9 +40,9 @@ This adds the atlasrootstyle macro directory to the ROOT include path.
 
 ### Components
 
-| File              | Purpose                                              |
-| ----------------- | ---------------------------------------------------- |
-| `AtlasStyle.C/h`  | Main style definitions: font, tick marks, margins    |
+| File              | Purpose                                               |
+| ----------------- | ----------------------------------------------------- |
+| `AtlasStyle.C/h`  | Main style definitions: font, tick marks, margins     |
 | `AtlasLabels.C/h` | Functions for placing official ATLAS labels on plots  |
 | `AtlasUtils.C/h`  | Utility functions: text, lines, boxes, marker legends |
 
@@ -61,13 +61,13 @@ This adds the atlasrootstyle macro directory to the ROOT include path.
 
 Label text follows ATLAS publication policy strictly:
 
-| Label text              | Usage                                         |
-| ----------------------- | --------------------------------------------- |
-| `"ATLAS"`               | Approved results in published papers          |
-| `"ATLAS Preliminary"`   | Conference results not yet in a paper         |
-| `"ATLAS Internal"`      | Results not for public distribution           |
-| `"ATLAS Simulation"`    | Simulation-only results (no real data)        |
-| `"ATLAS Work in Progress"` | Early-stage results, not for approval      |
+| Label text                 | Usage                                  |
+| -------------------------- | -------------------------------------- |
+| `"ATLAS"`                  | Approved results in published papers   |
+| `"ATLAS Preliminary"`      | Conference results not yet in a paper  |
+| `"ATLAS Internal"`         | Results not for public distribution    |
+| `"ATLAS Simulation"`       | Simulation-only results (no real data) |
+| `"ATLAS Work in Progress"` | Early-stage results, not for approval  |
 
 ## Canonical Patterns
 
@@ -201,8 +201,8 @@ myText(0.2, 0.78, 1, "#sqrt{s} = 13.6 TeV");
   all defaults.
 - **Use `#include`, not `gROOT->LoadMacro()`** in compiled C++ macros after
   `lsetup astyle` — the macros are on the ROOT include path.
-- **For PyROOT, use `gROOT.LoadMacro()`**: Python cannot use `#include`, so
-  load macros explicitly at runtime.
+- **For PyROOT, use `gROOT.LoadMacro()`**: Python cannot use `#include`, so load
+  macros explicitly at runtime.
 - **NDC coordinates for labels**: `ATLASLabel` and `myText` use Normalized
   Device Coordinates (0–1 range). Typical placement is `x=0.2, y=0.85` for the
   ATLAS label.

--- a/plugins/atlas/skills/astyle/SKILL.md
+++ b/plugins/atlas/skills/astyle/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: astyle
+description: >-
+  Use when creating ATLAS publication-quality plots with the official ATLAS ROOT
+  style macros (atlasrootstyle), applying SetAtlasStyle, placing ATLAS labels
+  (Internal, Preliminary, Simulation), using ATLASLabel or myText helper
+  functions, or following ATLAS publication plotting conventions in ROOT or
+  PyROOT.
+---
+
+# ATLAS ROOT Style (astyle)
+
+## Overview
+
+The ATLAS ROOT style macros (`atlasrootstyle`) provide the official
+publication-quality plotting style for all ATLAS papers, conference notes, and
+internal documents. The package defines consistent fonts, colors, axis labels,
+margins, and ATLAS label placement. Available via `lsetup astyle` or directly
+from the GitLab repository.
+
+## When to Use
+
+- Creating plots for an ATLAS paper, conference note, or internal document
+- Applying the official ATLAS style (fonts, margins, tick marks) to ROOT plots
+- Placing "ATLAS", "ATLAS Preliminary", "ATLAS Internal", or other official
+  labels on a canvas
+- Using helper functions for text, lines, boxes, and marker legends on plots
+- Setting up atlasrootstyle in a PyROOT or C++ ROOT macro
+
+## Key Concepts
+
+### Setup
+
+```bash
+setupATLAS
+lsetup astyle
+```
+
+This adds the atlasrootstyle macro directory to the ROOT include path.
+
+### Components
+
+| File              | Purpose                                              |
+| ----------------- | ---------------------------------------------------- |
+| `AtlasStyle.C/h`  | Main style definitions: font, tick marks, margins    |
+| `AtlasLabels.C/h` | Functions for placing official ATLAS labels on plots  |
+| `AtlasUtils.C/h`  | Utility functions: text, lines, boxes, marker legends |
+
+### Style Characteristics
+
+- **Font**: Helvetica (ROOT font family 43, size 26 for axis labels)
+- **Stat box**: Disabled by default
+- **Tick marks**: Drawn on all four sides of the pad
+- **Canvas**: 800x600 pixels by default
+- **Margins**: Optimized for publication (left, right, top, bottom tuned for
+  axis labels and titles)
+- **Title**: Histogram title display suppressed — use `ATLASLabel` and `myText`
+  instead
+
+### ATLAS Label Categories
+
+Label text follows ATLAS publication policy strictly:
+
+| Label text              | Usage                                         |
+| ----------------------- | --------------------------------------------- |
+| `"ATLAS"`               | Approved results in published papers          |
+| `"ATLAS Preliminary"`   | Conference results not yet in a paper         |
+| `"ATLAS Internal"`      | Results not for public distribution           |
+| `"ATLAS Simulation"`    | Simulation-only results (no real data)        |
+| `"ATLAS Work in Progress"` | Early-stage results, not for approval      |
+
+## Canonical Patterns
+
+### C++ ROOT Macro
+
+```cpp
+#include "AtlasStyle.C"
+#include "AtlasLabels.C"
+#include "AtlasUtils.C"
+
+void myPlot() {
+    SetAtlasStyle();
+
+    TCanvas *c = new TCanvas("c", "", 800, 600);
+    TH1F *h = new TH1F("h", "", 50, 0, 500);
+    // ... fill histogram ...
+
+    h->GetXaxis()->SetTitle("m_{jj} [GeV]");
+    h->GetYaxis()->SetTitle("Events / 10 GeV");
+    h->Draw();
+
+    // Place ATLAS label and luminosity text
+    ATLASLabel(0.2, 0.85, "Internal");
+    myText(0.2, 0.78, 1, "#sqrt{s} = 13 TeV, 140 fb^{-1}");
+}
+```
+
+### PyROOT
+
+```python
+import ROOT
+
+ROOT.gROOT.LoadMacro("AtlasStyle.C")
+ROOT.gROOT.LoadMacro("AtlasLabels.C")
+ROOT.gROOT.LoadMacro("AtlasUtils.C")
+ROOT.SetAtlasStyle()
+
+c = ROOT.TCanvas("c", "", 800, 600)
+h = ROOT.TH1F("h", "", 50, 0, 500)
+# ... fill histogram ...
+
+h.GetXaxis().SetTitle("m_{jj} [GeV]")
+h.GetYaxis().SetTitle("Events / 10 GeV")
+h.Draw()
+
+ROOT.ATLASLabel(0.2, 0.85, "Internal")
+ROOT.myText(0.2, 0.78, 1, "#sqrt{s} = 13 TeV, 140 fb^{-1}")
+
+c.SaveAs("my_plot.pdf")
+```
+
+### Helper Functions Reference
+
+```cpp
+// Apply the ATLAS style globally
+SetAtlasStyle();
+
+// Place official ATLAS label at (x, y) in NDC coordinates
+ATLASLabel(x, y, "Internal");        // "ATLAS Internal"
+ATLASLabel(x, y, "Preliminary");     // "ATLAS Preliminary"
+ATLASLabel(x, y, "");               // "ATLAS" alone (papers)
+
+// Place arbitrary text
+myText(x, y, color, "text");
+
+// Draw horizontal/vertical lines
+myLineH(x1, x2, y);                 // horizontal line
+myLineV(x, y1, y2);                 // vertical line
+
+// Draw legend-style boxes and markers with text
+myBoxText(x, y, boxsize, mcolor, "text");
+myMarkerText(x, y, mcolor, mstyle, "text");
+```
+
+### Ratio Plot Pattern
+
+```cpp
+SetAtlasStyle();
+
+TCanvas *c = new TCanvas("c", "", 800, 800);
+
+// Upper pad for main distribution
+TPad *pad1 = new TPad("pad1", "", 0, 0.35, 1, 1);
+pad1->SetBottomMargin(0.02);
+pad1->Draw();
+pad1->cd();
+h_data->Draw("E");
+h_mc->Draw("HIST SAME");
+ATLASLabel(0.2, 0.85, "Internal");
+
+// Lower pad for ratio
+c->cd();
+TPad *pad2 = new TPad("pad2", "", 0, 0, 1, 0.35);
+pad2->SetTopMargin(0.02);
+pad2->SetBottomMargin(0.3);
+pad2->Draw();
+pad2->cd();
+h_ratio->GetYaxis()->SetTitle("Data / MC");
+h_ratio->GetYaxis()->SetRangeUser(0.5, 1.5);
+h_ratio->Draw("E");
+```
+
+### Multi-Histogram with Legend
+
+```cpp
+SetAtlasStyle();
+
+TCanvas *c = new TCanvas("c", "", 800, 600);
+TLegend *leg = new TLegend(0.65, 0.65, 0.90, 0.85);
+leg->SetBorderSize(0);
+leg->SetFillStyle(0);
+leg->SetTextFont(43);
+leg->SetTextSize(20);
+
+h1->SetLineColor(kBlue);
+h2->SetLineColor(kRed);
+h1->Draw("HIST");
+h2->Draw("HIST SAME");
+leg->AddEntry(h1, "Background", "l");
+leg->AddEntry(h2, "Signal", "l");
+leg->Draw();
+
+ATLASLabel(0.2, 0.85, "Simulation");
+myText(0.2, 0.78, 1, "#sqrt{s} = 13.6 TeV");
+```
+
+## Gotchas
+
+- **Call `SetAtlasStyle()` before creating histograms or canvases**: Style
+  settings apply at object creation time. Calling it afterward may not override
+  all defaults.
+- **Use `#include`, not `gROOT->LoadMacro()`** in compiled C++ macros after
+  `lsetup astyle` — the macros are on the ROOT include path.
+- **For PyROOT, use `gROOT.LoadMacro()`**: Python cannot use `#include`, so
+  load macros explicitly at runtime.
+- **NDC coordinates for labels**: `ATLASLabel` and `myText` use Normalized
+  Device Coordinates (0–1 range). Typical placement is `x=0.2, y=0.85` for the
+  ATLAS label.
+- **No stat box**: The style disables the statistics box by default. To
+  re-enable, call `gStyle->SetOptStat(1)` after `SetAtlasStyle()`.
+- **Label text is policy**: Using the wrong label category (e.g. "ATLAS" on
+  unapproved results) violates ATLAS publication policy — see the label table
+  above.
+- **All ATLAS energy/momentum values are in MeV** in the detector/analysis
+  framework, but plot axis labels conventionally show GeV or TeV.
+
+## Interop
+
+- **setupATLAS / lsetup**: `lsetup astyle` is the standard way to configure the
+  macros — see the setupatlas skill for environment setup.
+- **ROOT**: atlasrootstyle targets ROOT 6; functions use ROOT C++ types
+  (`TCanvas`, `TH1`, `TLegend`).
+- **hist / uproot / matplotlib**: For Python-native plotting, the
+  [atlas-mpl-style](https://github.com/atlas-open-data/atlas-mpl-style) package
+  provides equivalent ATLAS styling for matplotlib — atlasrootstyle is
+  ROOT-specific.
+
+## Docs
+
+https://gitlab.cern.ch/atlas-publications-committee/atlasrootstyle

--- a/plugins/atlas/skills/astyle/SKILL.md
+++ b/plugins/atlas/skills/astyle/SKILL.md
@@ -220,10 +220,12 @@ myText(0.2, 0.78, 1, "#sqrt{s} = 13.6 TeV");
   macros — see the setupatlas skill for environment setup.
 - **ROOT**: atlasrootstyle targets ROOT 6; functions use ROOT C++ types
   (`TCanvas`, `TH1`, `TLegend`).
-- **hist / uproot / matplotlib**: For Python-native plotting, the
-  [atlas-mpl-style](https://github.com/atlas-open-data/atlas-mpl-style) package
-  provides equivalent ATLAS styling for matplotlib — atlasrootstyle is
-  ROOT-specific.
+- **mplhep (matplotlib)**: For Python-native plotting with matplotlib, the
+  mplhep skill covers `mplhep.style.use("ATLAS")` and `mplhep.atlas.label()` —
+  the matplotlib equivalent of `SetAtlasStyle` and `ATLASLabel`. The label
+  categories and publication policy rules are identical across both tools.
+- **hist / uproot**: Use with mplhep for a pure-Python plotting workflow;
+  atlasrootstyle is ROOT-specific.
 
 ## Docs
 

--- a/plugins/atlas/skills/atlantis/SKILL.md
+++ b/plugins/atlas/skills/atlantis/SKILL.md
@@ -32,7 +32,7 @@ calorimeter deposits, muon hits, and jets across multiple detector views.
 | Y-X projection   | Transverse view (beam axis perpendicular to screen)         |
 | R-Z projection   | Longitudinal view (beam axis horizontal)                    |
 | phi-eta view     | Unrolled detector view in pseudorapidity vs azimuthal angle |
-| Interactive cuts  | Apply pT, eta, or object-type filters directly in the GUI   |
+| Interactive cuts | Apply pT, eta, or object-type filters directly in the GUI   |
 
 ## Canonical Patterns
 

--- a/plugins/atlas/skills/atlantis/SKILL.md
+++ b/plugins/atlas/skills/atlantis/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: atlantis
+description: >-
+  Use when visualizing ATLAS detector events with the Atlantis event display:
+  launching the Atlantis GUI, opening JiveXML event files, producing JiveXML
+  output from Athena reconstruction, or troubleshooting Java runtime issues in
+  containerized environments.
+---
+
+# Atlantis
+
+## Overview
+
+Atlantis is the ATLAS event display — a Java-based graphical tool for
+visualizing detector events in 2D projections. It reads JiveXML files produced
+by the Athena JiveXML algorithm and provides interactive exploration of tracks,
+calorimeter deposits, muon hits, and jets across multiple detector views.
+
+## When to Use
+
+- Visualizing reconstructed ATLAS events interactively
+- Inspecting individual tracks, calorimeter clusters, or muon segments in 2D
+  projections
+- Producing event display images for talks, papers, or analysis documentation
+- Debugging reconstruction output by examining event geometry
+
+## Key Concepts
+
+| Concept          | Notes                                                       |
+| ---------------- | ----------------------------------------------------------- |
+| JiveXML          | XML format for event display data, produced by Athena       |
+| Y-X projection   | Transverse view (beam axis perpendicular to screen)         |
+| R-Z projection   | Longitudinal view (beam axis horizontal)                    |
+| phi-eta view     | Unrolled detector view in pseudorapidity vs azimuthal angle |
+| Interactive cuts  | Apply pT, eta, or object-type filters directly in the GUI   |
+
+## Canonical Patterns
+
+### Setup and launch
+
+```bash
+setupATLAS
+lsetup atlantis
+
+atlantis                         # launch GUI
+atlantis file.xml               # open specific JiveXML event file
+atlantis --file file.xml        # alternative syntax
+```
+
+### Producing JiveXML files from Athena
+
+Add the JiveXML algorithm to an Athena job to write event display data:
+
+```python
+from AthenaCommon.AlgSequence import AlgSequence
+topSequence = AlgSequence()
+from JiveXML.JiveXMLConf import JiveXML__AlgorithmJiveXML
+topSequence += JiveXML__AlgorithmJiveXML()
+```
+
+This writes one `.xml` file per event in the run directory. Control output with
+algorithm properties:
+
+```python
+jivexml = JiveXML__AlgorithmJiveXML()
+jivexml.AtlasRelease = "24.0.0"
+jivexml.WriteToFile = True
+jivexml.OnlineMode = False
+topSequence += jivexml
+```
+
+### Working with the GUI
+
+- **Navigate events**: Use the event browser toolbar to step through events in a
+  JiveXML file or directory
+- **Select objects**: Click on tracks or clusters to inspect properties (pT,
+  eta, phi, charge)
+- **Apply cuts**: Use the cut panel to filter objects by pT threshold, eta
+  range, or object type
+- **Export images**: File → Save Canvas to export the current view as PNG or EPS
+
+## Gotchas
+
+- **Java runtime required**: Atlantis is Java-based. Ensure a JRE is available
+  in the environment (`java -version` to check).
+- **Singularity/Apptainer issues**: Known Java display problems when running
+  inside containers — set `DISPLAY` correctly or use VNC/X11 forwarding.
+- **Large XML files**: Complex events with many tracks and clusters produce
+  large JiveXML files. Limit output to events of interest in Athena.
+- **All ATLAS energy/momentum values are in MeV**: Values displayed in the GUI
+  follow ATLAS conventions.
+- **Custom objects**: JiveXML output may need specific Athena configuration to
+  include non-standard reconstruction objects.
+
+## Interop
+
+- **setupATLAS**: `lsetup atlantis` requires a working ALRB environment — see
+  the setupatlas skill.
+- **Athena**: JiveXML files are produced by Athena reconstruction jobs; the
+  JiveXML algorithm must be added to the job sequence.
+
+Contact: hn-atlas-AtlantisDisplay@cern.ch
+
+## Docs
+
+https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/Atlantis
+
+Additional info: http://atlantis.web.cern.ch

--- a/plugins/atlas/skills/atlas-containers/SKILL.md
+++ b/plugins/atlas/skills/atlas-containers/SKILL.md
@@ -242,6 +242,21 @@ setupATLAS -c el9 --postsetup "source ~/mysetup.sh"
    python my_analysis.py
    ```
 
+## Troubleshooting
+
+| Symptom                               | Cause                                   | Fix                                                                                |
+| ------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
+| `setupATLAS -c` hangs on macOS        | Docker Desktop not running              | Start Docker Desktop, wait for engine ready                                        |
+| `FATAL: container creation failed`    | Apptainer not installed or too old      | Install Apptainer >= 1.0 or use `--swtype docker`                                  |
+| Files missing inside container        | Working dir not under `$HOME` or `$PWD` | Move files to `$HOME` or `$PWD`; add custom mounts with `-o "-v /host:/container"` |
+| `voms-proxy-init` timezone error      | Unpacked container TZ mismatch          | `export TZ=America/Chicago` or use `arcproxy`                                      |
+| X11 apps fail on macOS                | XQuartz not configured                  | Install XQuartz, enable network clients, restart                                   |
+| SSH auth fails inside Docker on macOS | Host SSH agent inaccessible             | Run `ssh-add` inside the container                                                 |
+| `Permission denied` on mounted files  | UID mapping mismatch (rootless Podman)  | Use Apptainer or Docker; or configure Podman UID mapping                           |
+| Container exits immediately with `-r` | Payload script has errors               | Test the script interactively first, check exit codes                              |
+| Hostname-related errors on macOS      | Special characters in computer name     | Change computer name to alphanumeric only in System Settings                       |
+| Java/Atlantis crashes in Singularity  | Known unresolved issue                  | No fix available; use Docker instead                                               |
+
 ## Gotchas
 
 - **macOS: Docker only.** Apptainer, Podman, and Shifter are unsupported on
@@ -270,21 +285,6 @@ setupATLAS -c el9 --postsetup "source ~/mysetup.sh"
 - **Exiting a joined Docker session.** When using `dockerJoin`, exiting kills
   only the joined session, not the original container. But be aware that
   processes started in the joined session terminate on exit.
-
-## Troubleshooting
-
-| Symptom                               | Cause                                   | Fix                                                                                |
-| ------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
-| `setupATLAS -c` hangs on macOS        | Docker Desktop not running              | Start Docker Desktop, wait for engine ready                                        |
-| `FATAL: container creation failed`    | Apptainer not installed or too old      | Install Apptainer >= 1.0 or use `--swtype docker`                                  |
-| Files missing inside container        | Working dir not under `$HOME` or `$PWD` | Move files to `$HOME` or `$PWD`; add custom mounts with `-o "-v /host:/container"` |
-| `voms-proxy-init` timezone error      | Unpacked container TZ mismatch          | `export TZ=America/Chicago` or use `arcproxy`                                      |
-| X11 apps fail on macOS                | XQuartz not configured                  | Install XQuartz, enable network clients, restart                                   |
-| SSH auth fails inside Docker on macOS | Host SSH agent inaccessible             | Run `ssh-add` inside the container                                                 |
-| `Permission denied` on mounted files  | UID mapping mismatch (rootless Podman)  | Use Apptainer or Docker; or configure Podman UID mapping                           |
-| Container exits immediately with `-r` | Payload script has errors               | Test the script interactively first, check exit codes                              |
-| Hostname-related errors on macOS      | Special characters in computer name     | Change computer name to alphanumeric only in System Settings                       |
-| Java/Atlantis crashes in Singularity  | Known unresolved issue                  | No fix available; use Docker instead                                               |
 
 ## Interop
 

--- a/plugins/atlas/skills/atlas-containers/SKILL.md
+++ b/plugins/atlas/skills/atlas-containers/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: atlas-containers
+description: >-
+  Use when running ATLAS software inside containers via setupATLAS -c, choosing
+  between Apptainer/Docker/Podman/Shifter, setting up containers on macOS or
+  without CVMFS, mounting directories, passing GPU flags, submitting batch jobs
+  from containers, using custom or standalone container images, joining Docker
+  sessions, or debugging container-related issues like timezone, symlink, or
+  SSH-agent problems.
+---
+
+# ATLAS Containers
+
+## Overview
+
+ATLAS containers provide a reproducible OS environment (CentOS 7, AlmaLinux 9,
+etc.) for running ATLAS software, independent of the host operating system.
+The `setupATLAS -c` command launches a container shell with CVMFS, home
+directory, and working directory mounted automatically. Containers are the
+standard way to run ATLAS software on macOS, on older Linux hosts that need a
+newer OS, or in batch systems where the host OS does not match the release
+requirements.
+
+## When to Use
+
+- Running ATLAS software on macOS (Docker required)
+- Running EL9 releases on a CentOS 7 host (or vice versa)
+- Working on a machine without CVMFS (standalone setupATLAS download)
+- Using custom container images from Docker Hub or GitLab registries
+- Submitting batch jobs that need a containerized environment
+- Passing GPU flags to the container runtime
+- Debugging container mount, timezone, or SSH issues
+
+## Key Concepts
+
+**Container software support:**
+
+| Platform | Apptainer  | Docker    | Podman       | Shifter   |
+| -------- | ---------- | --------- | ------------ | --------- |
+| Linux    | Supported  | Supported | Supported    | Supported |
+| macOS    | No support | Supported | No support   | No support|
+
+On Linux, Apptainer (formerly Singularity) is the default. On macOS, Docker
+Desktop is the only supported runtime.
+
+**Container type auto-detection:**
+
+When entering a container, setupATLAS inspects the image and classifies it:
+
+| Type             | Trigger                  | Behavior                          |
+| ---------------- | ------------------------ | --------------------------------- |
+| atlas-default    | Standard ATLAS base image| Runs setupATLAS inside container  |
+| atlas-standalone | Has `/release_setup.sh`  | Skips auto setupATLAS             |
+| non-atlas        | Non-ATLAS image          | Skips auto setupATLAS             |
+
+**Mount points (automatic):**
+
+| Host     | Container  | Notes                          |
+| -------- | ---------- | ------------------------------ |
+| `$TMPDIR`| `/scratch` | Temporary storage              |
+| `$PWD`   | `/srv`     | Working directory at entry     |
+| `$HOME`  | `/home/<user>` | Home directory             |
+| `/cvmfs` | `/cvmfs`   | CVMFS software repository      |
+
+**Login scripts:** Container shells source dedicated rc files instead of the
+host login scripts:
+
+- `$HOME/.bashrc.container` — bash
+- `$HOME/.zshrc.container` — zsh
+- `$HOME/.ssh.container` — SSH configuration
+
+Create these files to customize the container shell environment without
+affecting the host shell.
+
+See `references/container-options.md` for the full option table and advanced
+configuration environment variables.
+
+## Canonical Patterns
+
+### Enter a container shell
+
+```bash
+setupATLAS -c centos7        # CentOS 7 container
+setupATLAS -c el9            # AlmaLinux 9 container
+```
+
+After entering, the standard setupATLAS menu appears and `asetup`/`lsetup` are
+available inside the container.
+
+### List available containers
+
+```bash
+setupATLAS -c --showVersions          # list all available containers
+setupATLAS -c find=analysisbase,24.2,alma9  # search for specific image
+queryC analysisbase                   # query containers on CVMFS
+```
+
+### Use a custom container image
+
+```bash
+# Docker Hub image
+setupATLAS -c docker://atlas/analysisbase:21.2.85-centos7
+
+# GitLab registry image
+setupATLAS -c docker://gitlab-registry.cern.ch/atlas/athena/analysisbase:24.2.0
+```
+
+### Standalone container (atlas-standalone type)
+
+For images that ship a pre-built release (detected by `/release_setup.sh`),
+setupATLAS does not run automatically inside. Source the release manually:
+
+```bash
+setupATLAS -c docker://gitlab-registry.cern.ch/atlas/athena/analysisbase:24.2.0
+# Inside the container:
+source /release_setup.sh
+source /alrb/postATLASReleaseSetup.sh
+```
+
+### Run without CVMFS (standalone setupATLAS)
+
+Download the standalone bootstrap when CVMFS is unavailable:
+
+```bash
+curl -O https://atlas-tier3-sw.web.cern.ch/containers/setupATLAS
+chmod +x ./setupATLAS
+./setupATLAS -c el9
+```
+
+This downloads the container image and enters it. CVMFS is accessed from
+inside the container via the automounter.
+
+### GPU passthrough
+
+```bash
+# Apptainer/Singularity (Linux)
+setupATLAS -c centos7 -e "--nv"
+
+# Docker (Linux or macOS)
+setupATLAS -c centos7 -e "--gpus all"
+```
+
+The `-e` flag passes runtime exec options directly to the container backend.
+
+### Batch submission from containers
+
+Enter the container with the `-b` flag to enable batch mode, then generate
+submission scripts:
+
+```bash
+setupATLAS -c centos7 -b
+batchScript "source /path/myJob.sh" -o submitMyJob.sh
+
+# Submit to SLURM
+sbatch --export=NONE submitMyJob.sh
+
+# Submit to LSF
+bsub -L /bin/bash submitMyJob.sh
+```
+
+The `-b` flag configures the container for non-interactive batch execution.
+
+### Force a specific container runtime
+
+```bash
+# Force Docker on a Linux system that has both Apptainer and Docker
+setupATLAS -c el9 --swtype docker
+
+# Force Podman
+setupATLAS -c el9 --swtype podman
+```
+
+Or set the environment variable before entering:
+
+```bash
+export ALRB_CONT_SWTYPE=docker
+setupATLAS -c el9
+```
+
+### Join an existing Docker container
+
+```bash
+export ALRB_CONT_CONDUCT="dockerJoin"
+setupATLAS -c <container>
+```
+
+This attaches to an already-running Docker container instead of starting a new
+one. Warning: exiting the joined session kills that session only, but the
+original container keeps running.
+
+### Run a command and exit
+
+```bash
+# Execute a payload inside the container without an interactive shell
+setupATLAS -c el9 -r "asetup StatAnalysis,0.7,latest && myScript.sh"
+```
+
+### Pre/post setup hooks
+
+```bash
+# Run commands before setupATLAS runs inside the container
+setupATLAS -c el9 --presetup "export MY_VAR=foo"
+
+# Run commands after setupATLAS completes inside the container
+setupATLAS -c el9 --postsetup "source ~/mysetup.sh"
+```
+
+## Worked Example
+
+**Scenario:** Run a StatAnalysis job on macOS where Apptainer is unavailable.
+
+1. Install Docker Desktop for macOS and start it.
+
+2. Download standalone setupATLAS (if CVMFS is not available):
+
+   ```bash
+   curl -O https://atlas-tier3-sw.web.cern.ch/containers/setupATLAS
+   chmod +x ./setupATLAS
+   ```
+
+3. Enter an EL9 container:
+
+   ```bash
+   ./setupATLAS -c el9
+   ```
+
+4. Inside the container, set up the analysis release:
+
+   ```bash
+   setupATLAS
+   asetup StatAnalysis,0.7,latest
+   ```
+
+5. Create a container-specific login script so future shells auto-configure:
+
+   ```bash
+   cat > $HOME/.bashrc.container << 'EOF'
+   # Container-specific setup
+   export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+   alias setupATLAS='source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh'
+   EOF
+   ```
+
+6. Run the analysis:
+
+   ```bash
+   cd /srv    # maps to $PWD on the host
+   python my_analysis.py
+   ```
+
+## Gotchas
+
+- **macOS: Docker only.** Apptainer, Podman, and Shifter are unsupported on
+  macOS. Install Docker Desktop.
+- **macOS: case-insensitive filesystem.** The default macOS filesystem is
+  case-insensitive (HFS+/APFS). File-name collisions can occur with ATLAS
+  software that assumes case-sensitive paths. Consider a case-sensitive APFS
+  volume for the working directory.
+- **macOS: hostname restrictions.** The computer name must contain only
+  `A-Za-z0-9` characters (no hyphens or special characters), or container
+  startup may fail.
+- **macOS: X11 forwarding.** Install XQuartz and enable "Allow connections
+  from network clients" in XQuartz preferences for GUI applications.
+- **macOS: SSH agent.** Docker on macOS cannot access the host SSH agent. Run
+  `ssh-add` inside the container after entering.
+- **Relative symlinks only.** Absolute symlinks break inside containers
+  because host paths differ from container paths. Always use relative symlinks
+  in the working directory.
+- **Timezone issue with voms-proxy.** In unpacked Apptainer containers,
+  `voms-proxy-init` can fail with timezone errors. Fix with
+  `export TZ=<timezone>` (e.g. `export TZ=America/Chicago`) or use `arcproxy`
+  as an alternative.
+- **ATLAS units are MeV.** All ATLAS energy, momentum, and mass values are in
+  MeV, not GeV. This applies to ROOT files, xAOD containers, and framework
+  outputs accessed from within containers.
+- **Exiting a joined Docker session.** When using `dockerJoin`, exiting kills
+  only the joined session, not the original container. But be aware that
+  processes started in the joined session terminate on exit.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| ------- | ----- | --- |
+| `setupATLAS -c` hangs on macOS | Docker Desktop not running | Start Docker Desktop, wait for engine ready |
+| `FATAL: container creation failed` | Apptainer not installed or too old | Install Apptainer >= 1.0 or use `--swtype docker` |
+| Files missing inside container | Working dir not under `$HOME` or `$PWD` | Move files to `$HOME` or `$PWD`; add custom mounts with `-o "-v /host:/container"` |
+| `voms-proxy-init` timezone error | Unpacked container TZ mismatch | `export TZ=America/Chicago` or use `arcproxy` |
+| X11 apps fail on macOS | XQuartz not configured | Install XQuartz, enable network clients, restart |
+| SSH auth fails inside Docker on macOS | Host SSH agent inaccessible | Run `ssh-add` inside the container |
+| `Permission denied` on mounted files | UID mapping mismatch (rootless Podman) | Use Apptainer or Docker; or configure Podman UID mapping |
+| Container exits immediately with `-r` | Payload script has errors | Test the script interactively first, check exit codes |
+| Hostname-related errors on macOS | Special characters in computer name | Change computer name to alphanumeric only in System Settings |
+| Java/Atlantis crashes in Singularity | Known unresolved issue | No fix available; use Docker instead |
+
+## Interop
+
+- **setupATLAS**: The `setupATLAS -c` flag is the container entry point —
+  see the setupatlas skill for `asetup`, `lsetup`, and `acm` usage after
+  entering.
+- **StatAnalysis**: Enter an EL9 container, then
+  `asetup StatAnalysis,0.7,latest` — see the statanalysis skill.
+- **Batch systems**: The `-b` flag integrates with SLURM (`sbatch`) and LSF
+  (`bsub`) schedulers at ATLAS sites.
+- **Rucio/PanDA**: Grid tools work inside containers after
+  `voms-proxy-init --voms atlas` — see the setupatlas skill for grid
+  patterns.
+
+## Docs
+
+https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Containers
+
+### Reference Files
+
+- **`references/container-options.md`** — Full container option table,
+  environment variables, advanced runtime configuration, and conduct keywords.

--- a/plugins/atlas/skills/atlas-containers/SKILL.md
+++ b/plugins/atlas/skills/atlas-containers/SKILL.md
@@ -230,15 +230,10 @@ setupATLAS -c el9 --postsetup "source ~/mysetup.sh"
    asetup StatAnalysis,0.7,latest
    ```
 
-5. Create a container-specific login script so future shells auto-configure:
-
-   ```bash
-   cat > $HOME/.bashrc.container << 'EOF'
-   # Container-specific setup
-   export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
-   alias setupATLAS='source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh'
-   EOF
-   ```
+5. Create a container-specific login script so future shells auto-configure. Add
+   the standard setupATLAS initialization (see the setupatlas skill) to
+   `$HOME/.bashrc.container` — container shells source this file instead of
+   `~/.bashrc`.
 
 6. Run the analysis:
 

--- a/plugins/atlas/skills/atlas-containers/SKILL.md
+++ b/plugins/atlas/skills/atlas-containers/SKILL.md
@@ -14,12 +14,11 @@ description: >-
 ## Overview
 
 ATLAS containers provide a reproducible OS environment (CentOS 7, AlmaLinux 9,
-etc.) for running ATLAS software, independent of the host operating system.
-The `setupATLAS -c` command launches a container shell with CVMFS, home
-directory, and working directory mounted automatically. Containers are the
-standard way to run ATLAS software on macOS, on older Linux hosts that need a
-newer OS, or in batch systems where the host OS does not match the release
-requirements.
+etc.) for running ATLAS software, independent of the host operating system. The
+`setupATLAS -c` command launches a container shell with CVMFS, home directory,
+and working directory mounted automatically. Containers are the standard way to
+run ATLAS software on macOS, on older Linux hosts that need a newer OS, or in
+batch systems where the host OS does not match the release requirements.
 
 ## When to Use
 
@@ -35,10 +34,10 @@ requirements.
 
 **Container software support:**
 
-| Platform | Apptainer  | Docker    | Podman       | Shifter   |
-| -------- | ---------- | --------- | ------------ | --------- |
-| Linux    | Supported  | Supported | Supported    | Supported |
-| macOS    | No support | Supported | No support   | No support|
+| Platform | Apptainer  | Docker    | Podman     | Shifter    |
+| -------- | ---------- | --------- | ---------- | ---------- |
+| Linux    | Supported  | Supported | Supported  | Supported  |
+| macOS    | No support | Supported | No support | No support |
 
 On Linux, Apptainer (formerly Singularity) is the default. On macOS, Docker
 Desktop is the only supported runtime.
@@ -47,20 +46,20 @@ Desktop is the only supported runtime.
 
 When entering a container, setupATLAS inspects the image and classifies it:
 
-| Type             | Trigger                  | Behavior                          |
-| ---------------- | ------------------------ | --------------------------------- |
-| atlas-default    | Standard ATLAS base image| Runs setupATLAS inside container  |
-| atlas-standalone | Has `/release_setup.sh`  | Skips auto setupATLAS             |
-| non-atlas        | Non-ATLAS image          | Skips auto setupATLAS             |
+| Type             | Trigger                   | Behavior                         |
+| ---------------- | ------------------------- | -------------------------------- |
+| atlas-default    | Standard ATLAS base image | Runs setupATLAS inside container |
+| atlas-standalone | Has `/release_setup.sh`   | Skips auto setupATLAS            |
+| non-atlas        | Non-ATLAS image           | Skips auto setupATLAS            |
 
 **Mount points (automatic):**
 
-| Host     | Container  | Notes                          |
-| -------- | ---------- | ------------------------------ |
-| `$TMPDIR`| `/scratch` | Temporary storage              |
-| `$PWD`   | `/srv`     | Working directory at entry     |
-| `$HOME`  | `/home/<user>` | Home directory             |
-| `/cvmfs` | `/cvmfs`   | CVMFS software repository      |
+| Host      | Container      | Notes                      |
+| --------- | -------------- | -------------------------- |
+| `$TMPDIR` | `/scratch`     | Temporary storage          |
+| `$PWD`    | `/srv`         | Working directory at entry |
+| `$HOME`   | `/home/<user>` | Home directory             |
+| `/cvmfs`  | `/cvmfs`       | CVMFS software repository  |
 
 **Login scripts:** Container shells source dedicated rc files instead of the
 host login scripts:
@@ -127,8 +126,8 @@ chmod +x ./setupATLAS
 ./setupATLAS -c el9
 ```
 
-This downloads the container image and enters it. CVMFS is accessed from
-inside the container via the automounter.
+This downloads the container image and enters it. CVMFS is accessed from inside
+the container via the automounter.
 
 ### GPU passthrough
 
@@ -259,17 +258,17 @@ setupATLAS -c el9 --postsetup "source ~/mysetup.sh"
 - **macOS: hostname restrictions.** The computer name must contain only
   `A-Za-z0-9` characters (no hyphens or special characters), or container
   startup may fail.
-- **macOS: X11 forwarding.** Install XQuartz and enable "Allow connections
-  from network clients" in XQuartz preferences for GUI applications.
+- **macOS: X11 forwarding.** Install XQuartz and enable "Allow connections from
+  network clients" in XQuartz preferences for GUI applications.
 - **macOS: SSH agent.** Docker on macOS cannot access the host SSH agent. Run
   `ssh-add` inside the container after entering.
-- **Relative symlinks only.** Absolute symlinks break inside containers
-  because host paths differ from container paths. Always use relative symlinks
-  in the working directory.
+- **Relative symlinks only.** Absolute symlinks break inside containers because
+  host paths differ from container paths. Always use relative symlinks in the
+  working directory.
 - **Timezone issue with voms-proxy.** In unpacked Apptainer containers,
   `voms-proxy-init` can fail with timezone errors. Fix with
-  `export TZ=<timezone>` (e.g. `export TZ=America/Chicago`) or use `arcproxy`
-  as an alternative.
+  `export TZ=<timezone>` (e.g. `export TZ=America/Chicago`) or use `arcproxy` as
+  an alternative.
 - **ATLAS units are MeV.** All ATLAS energy, momentum, and mass values are in
   MeV, not GeV. This applies to ROOT files, xAOD containers, and framework
   outputs accessed from within containers.
@@ -279,31 +278,29 @@ setupATLAS -c el9 --postsetup "source ~/mysetup.sh"
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-| ------- | ----- | --- |
-| `setupATLAS -c` hangs on macOS | Docker Desktop not running | Start Docker Desktop, wait for engine ready |
-| `FATAL: container creation failed` | Apptainer not installed or too old | Install Apptainer >= 1.0 or use `--swtype docker` |
-| Files missing inside container | Working dir not under `$HOME` or `$PWD` | Move files to `$HOME` or `$PWD`; add custom mounts with `-o "-v /host:/container"` |
-| `voms-proxy-init` timezone error | Unpacked container TZ mismatch | `export TZ=America/Chicago` or use `arcproxy` |
-| X11 apps fail on macOS | XQuartz not configured | Install XQuartz, enable network clients, restart |
-| SSH auth fails inside Docker on macOS | Host SSH agent inaccessible | Run `ssh-add` inside the container |
-| `Permission denied` on mounted files | UID mapping mismatch (rootless Podman) | Use Apptainer or Docker; or configure Podman UID mapping |
-| Container exits immediately with `-r` | Payload script has errors | Test the script interactively first, check exit codes |
-| Hostname-related errors on macOS | Special characters in computer name | Change computer name to alphanumeric only in System Settings |
-| Java/Atlantis crashes in Singularity | Known unresolved issue | No fix available; use Docker instead |
+| Symptom                               | Cause                                   | Fix                                                                                |
+| ------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
+| `setupATLAS -c` hangs on macOS        | Docker Desktop not running              | Start Docker Desktop, wait for engine ready                                        |
+| `FATAL: container creation failed`    | Apptainer not installed or too old      | Install Apptainer >= 1.0 or use `--swtype docker`                                  |
+| Files missing inside container        | Working dir not under `$HOME` or `$PWD` | Move files to `$HOME` or `$PWD`; add custom mounts with `-o "-v /host:/container"` |
+| `voms-proxy-init` timezone error      | Unpacked container TZ mismatch          | `export TZ=America/Chicago` or use `arcproxy`                                      |
+| X11 apps fail on macOS                | XQuartz not configured                  | Install XQuartz, enable network clients, restart                                   |
+| SSH auth fails inside Docker on macOS | Host SSH agent inaccessible             | Run `ssh-add` inside the container                                                 |
+| `Permission denied` on mounted files  | UID mapping mismatch (rootless Podman)  | Use Apptainer or Docker; or configure Podman UID mapping                           |
+| Container exits immediately with `-r` | Payload script has errors               | Test the script interactively first, check exit codes                              |
+| Hostname-related errors on macOS      | Special characters in computer name     | Change computer name to alphanumeric only in System Settings                       |
+| Java/Atlantis crashes in Singularity  | Known unresolved issue                  | No fix available; use Docker instead                                               |
 
 ## Interop
 
-- **setupATLAS**: The `setupATLAS -c` flag is the container entry point —
-  see the setupatlas skill for `asetup`, `lsetup`, and `acm` usage after
-  entering.
+- **setupATLAS**: The `setupATLAS -c` flag is the container entry point — see
+  the setupatlas skill for `asetup`, `lsetup`, and `acm` usage after entering.
 - **StatAnalysis**: Enter an EL9 container, then
   `asetup StatAnalysis,0.7,latest` — see the statanalysis skill.
 - **Batch systems**: The `-b` flag integrates with SLURM (`sbatch`) and LSF
   (`bsub`) schedulers at ATLAS sites.
 - **Rucio/PanDA**: Grid tools work inside containers after
-  `voms-proxy-init --voms atlas` — see the setupatlas skill for grid
-  patterns.
+  `voms-proxy-init --voms atlas` — see the setupatlas skill for grid patterns.
 
 ## Docs
 

--- a/plugins/atlas/skills/atlas-containers/references/container-options.md
+++ b/plugins/atlas/skills/atlas-containers/references/container-options.md
@@ -5,66 +5,66 @@
 
 ## Command-line options
 
-| Option             | Env var equivalent      | Description                                    |
-| ------------------ | ----------------------- | ---------------------------------------------- |
-| `-c <image>`       |                         | Enter container (e.g. `centos7`, `el9`)        |
-| `-b`               |                         | Enable batch mode for job submission           |
-| `-e`, `--execopt`  | `ALRB_CONT_CMDOPTS`    | Runtime exec options (e.g. `"--nv"` for GPU)   |
-| `-o`, `--runopt`   | `ALRB_CONT_OPTS`       | Runtime options passed to container engine     |
-| `-r`, `--runpayload`| `ALRB_CONT_RUNPAYLOAD` | Run commands inside container and exit         |
-| `-s`, `--setupfile`| `ALRB_CONT_SETUPFILE`  | Source this file inside the container          |
-| `--swtype`         | `ALRB_CONT_SWTYPE`     | Force container software: apptainer, docker, podman, shifter |
-| `--conduct`        | `ALRB_CONT_CONDUCT`    | Behavior keywords (see below)                  |
-| `--presetup`       | `ALRB_CONT_PRESETUP`   | Commands to run before setupATLAS in container |
-| `--postsetup`      | `ALRB_CONT_POSTSETUP`  | Commands to run after setupATLAS in container  |
-| `--showVersions`   |                         | List available container images                |
+| Option               | Env var equivalent     | Description                                                  |
+| -------------------- | ---------------------- | ------------------------------------------------------------ |
+| `-c <image>`         |                        | Enter container (e.g. `centos7`, `el9`)                      |
+| `-b`                 |                        | Enable batch mode for job submission                         |
+| `-e`, `--execopt`    | `ALRB_CONT_CMDOPTS`    | Runtime exec options (e.g. `"--nv"` for GPU)                 |
+| `-o`, `--runopt`     | `ALRB_CONT_OPTS`       | Runtime options passed to container engine                   |
+| `-r`, `--runpayload` | `ALRB_CONT_RUNPAYLOAD` | Run commands inside container and exit                       |
+| `-s`, `--setupfile`  | `ALRB_CONT_SETUPFILE`  | Source this file inside the container                        |
+| `--swtype`           | `ALRB_CONT_SWTYPE`     | Force container software: apptainer, docker, podman, shifter |
+| `--conduct`          | `ALRB_CONT_CONDUCT`    | Behavior keywords (see below)                                |
+| `--presetup`         | `ALRB_CONT_PRESETUP`   | Commands to run before setupATLAS in container               |
+| `--postsetup`        | `ALRB_CONT_POSTSETUP`  | Commands to run after setupATLAS in container                |
+| `--showVersions`     |                        | List available container images                              |
 
 ## Environment variables
 
-Set these before running `setupATLAS -c` to control container behavior
-without command-line flags.
+Set these before running `setupATLAS -c` to control container behavior without
+command-line flags.
 
-| Variable                 | Description                                       |
-| ------------------------ | ------------------------------------------------- |
-| `ALRB_CONT_CMDOPTS`     | Extra exec options for the container runtime      |
-| `ALRB_CONT_OPTS`        | Extra run options for the container runtime       |
-| `ALRB_CONT_RUNPAYLOAD`  | Payload command string; container exits after run  |
-| `ALRB_CONT_SETUPFILE`   | Path to script sourced inside container           |
-| `ALRB_CONT_SWTYPE`      | Container backend: `apptainer`, `docker`, `podman`, `shifter` |
-| `ALRB_CONT_CONDUCT`     | Comma-separated behavior keywords                 |
-| `ALRB_CONT_PRESETUP`    | Commands run before setupATLAS in container       |
-| `ALRB_CONT_POSTSETUP`   | Commands run after setupATLAS in container        |
+| Variable               | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `ALRB_CONT_CMDOPTS`    | Extra exec options for the container runtime                  |
+| `ALRB_CONT_OPTS`       | Extra run options for the container runtime                   |
+| `ALRB_CONT_RUNPAYLOAD` | Payload command string; container exits after run             |
+| `ALRB_CONT_SETUPFILE`  | Path to script sourced inside container                       |
+| `ALRB_CONT_SWTYPE`     | Container backend: `apptainer`, `docker`, `podman`, `shifter` |
+| `ALRB_CONT_CONDUCT`    | Comma-separated behavior keywords                             |
+| `ALRB_CONT_PRESETUP`   | Commands run before setupATLAS in container                   |
+| `ALRB_CONT_POSTSETUP`  | Commands run after setupATLAS in container                    |
 
 ## Conduct keywords
 
-The `--conduct` option (or `ALRB_CONT_CONDUCT` env var) accepts
-comma-separated keywords that modify container behavior:
+The `--conduct` option (or `ALRB_CONT_CONDUCT` env var) accepts comma-separated
+keywords that modify container behavior:
 
-| Keyword       | Effect                                                    |
-| ------------- | --------------------------------------------------------- |
-| `dockerJoin`  | Attach to an existing Docker container instead of starting a new one |
+| Keyword      | Effect                                                               |
+| ------------ | -------------------------------------------------------------------- |
+| `dockerJoin` | Attach to an existing Docker container instead of starting a new one |
 
 ## Image name syntax
 
-| Form                                        | Example                                                          |
-| ------------------------------------------- | ---------------------------------------------------------------- |
-| Short alias                                 | `centos7`, `el9`                                                 |
-| Docker Hub reference                        | `docker://atlas/analysisbase:21.2.85-centos7`                    |
-| GitLab registry reference                   | `docker://gitlab-registry.cern.ch/atlas/athena/analysisbase:24.2.0` |
-| Search pattern                              | `find=analysisbase,24.2,alma9`                                   |
+| Form                      | Example                                                             |
+| ------------------------- | ------------------------------------------------------------------- |
+| Short alias               | `centos7`, `el9`                                                    |
+| Docker Hub reference      | `docker://atlas/analysisbase:21.2.85-centos7`                       |
+| GitLab registry reference | `docker://gitlab-registry.cern.ch/atlas/athena/analysisbase:24.2.0` |
+| Search pattern            | `find=analysisbase,24.2,alma9`                                      |
 
-Short aliases resolve to CVMFS-hosted Apptainer images. Docker references
-pull from the specified registry.
+Short aliases resolve to CVMFS-hosted Apptainer images. Docker references pull
+from the specified registry.
 
 ## Container type detection
 
 setupATLAS auto-detects image type and adjusts behavior:
 
-| Type             | Detection rule                    | setupATLAS inside? |
-| ---------------- | --------------------------------- | ------------------ |
-| atlas-default    | Standard ATLAS base image         | Yes                |
-| atlas-standalone | `/release_setup.sh` exists        | No                 |
-| non-atlas        | Not an ATLAS image                | No                 |
+| Type             | Detection rule             | setupATLAS inside? |
+| ---------------- | -------------------------- | ------------------ |
+| atlas-default    | Standard ATLAS base image  | Yes                |
+| atlas-standalone | `/release_setup.sh` exists | No                 |
+| non-atlas        | Not an ATLAS image         | No                 |
 
 For atlas-standalone images, source the release manually:
 
@@ -77,12 +77,12 @@ source /alrb/postATLASReleaseSetup.sh
 
 These directories are mounted automatically:
 
-| Host       | Container      | Notes                            |
-| ---------- | -------------- | -------------------------------- |
-| `$TMPDIR`  | `/scratch`     | Temporary storage                |
-| `$PWD`     | `/srv`         | Working directory at entry       |
-| `$HOME`    | `/home/<user>` | Home directory                   |
-| `/cvmfs`   | `/cvmfs`       | CVMFS software repository        |
+| Host      | Container      | Notes                      |
+| --------- | -------------- | -------------------------- |
+| `$TMPDIR` | `/scratch`     | Temporary storage          |
+| `$PWD`    | `/srv`         | Working directory at entry |
+| `$HOME`   | `/home/<user>` | Home directory             |
+| `/cvmfs`  | `/cvmfs`       | CVMFS software repository  |
 
 Add custom mounts via the `-o` flag:
 
@@ -96,8 +96,8 @@ setupATLAS -c el9 -o "-B /data/mydata:/data/mydata"
 
 ## Login scripts
 
-Container shells source these files (if they exist) instead of the host
-login scripts:
+Container shells source these files (if they exist) instead of the host login
+scripts:
 
 | Shell | File                      |
 | ----- | ------------------------- |
@@ -129,11 +129,11 @@ batchScript "source /path/myJob.sh" -o submitMyJob.sh
 
 Submit the generated script to the local scheduler:
 
-| Scheduler | Command                                |
-| --------- | -------------------------------------- |
-| SLURM     | `sbatch --export=NONE submitMyJob.sh`  |
-| LSF       | `bsub -L /bin/bash submitMyJob.sh`     |
-| HTCondor  | `condor_submit submitMyJob.sub`        |
+| Scheduler | Command                               |
+| --------- | ------------------------------------- |
+| SLURM     | `sbatch --export=NONE submitMyJob.sh` |
+| LSF       | `bsub -L /bin/bash submitMyJob.sh`    |
+| HTCondor  | `condor_submit submitMyJob.sub`       |
 
-The `--export=NONE` flag for SLURM prevents host environment leakage into
-the container job.
+The `--export=NONE` flag for SLURM prevents host environment leakage into the
+container job.

--- a/plugins/atlas/skills/atlas-containers/references/container-options.md
+++ b/plugins/atlas/skills/atlas-containers/references/container-options.md
@@ -1,0 +1,139 @@
+# Container Options Reference
+
+- Containers documentation:
+  https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Containers
+
+## Command-line options
+
+| Option             | Env var equivalent      | Description                                    |
+| ------------------ | ----------------------- | ---------------------------------------------- |
+| `-c <image>`       |                         | Enter container (e.g. `centos7`, `el9`)        |
+| `-b`               |                         | Enable batch mode for job submission           |
+| `-e`, `--execopt`  | `ALRB_CONT_CMDOPTS`    | Runtime exec options (e.g. `"--nv"` for GPU)   |
+| `-o`, `--runopt`   | `ALRB_CONT_OPTS`       | Runtime options passed to container engine     |
+| `-r`, `--runpayload`| `ALRB_CONT_RUNPAYLOAD` | Run commands inside container and exit         |
+| `-s`, `--setupfile`| `ALRB_CONT_SETUPFILE`  | Source this file inside the container          |
+| `--swtype`         | `ALRB_CONT_SWTYPE`     | Force container software: apptainer, docker, podman, shifter |
+| `--conduct`        | `ALRB_CONT_CONDUCT`    | Behavior keywords (see below)                  |
+| `--presetup`       | `ALRB_CONT_PRESETUP`   | Commands to run before setupATLAS in container |
+| `--postsetup`      | `ALRB_CONT_POSTSETUP`  | Commands to run after setupATLAS in container  |
+| `--showVersions`   |                         | List available container images                |
+
+## Environment variables
+
+Set these before running `setupATLAS -c` to control container behavior
+without command-line flags.
+
+| Variable                 | Description                                       |
+| ------------------------ | ------------------------------------------------- |
+| `ALRB_CONT_CMDOPTS`     | Extra exec options for the container runtime      |
+| `ALRB_CONT_OPTS`        | Extra run options for the container runtime       |
+| `ALRB_CONT_RUNPAYLOAD`  | Payload command string; container exits after run  |
+| `ALRB_CONT_SETUPFILE`   | Path to script sourced inside container           |
+| `ALRB_CONT_SWTYPE`      | Container backend: `apptainer`, `docker`, `podman`, `shifter` |
+| `ALRB_CONT_CONDUCT`     | Comma-separated behavior keywords                 |
+| `ALRB_CONT_PRESETUP`    | Commands run before setupATLAS in container       |
+| `ALRB_CONT_POSTSETUP`   | Commands run after setupATLAS in container        |
+
+## Conduct keywords
+
+The `--conduct` option (or `ALRB_CONT_CONDUCT` env var) accepts
+comma-separated keywords that modify container behavior:
+
+| Keyword       | Effect                                                    |
+| ------------- | --------------------------------------------------------- |
+| `dockerJoin`  | Attach to an existing Docker container instead of starting a new one |
+
+## Image name syntax
+
+| Form                                        | Example                                                          |
+| ------------------------------------------- | ---------------------------------------------------------------- |
+| Short alias                                 | `centos7`, `el9`                                                 |
+| Docker Hub reference                        | `docker://atlas/analysisbase:21.2.85-centos7`                    |
+| GitLab registry reference                   | `docker://gitlab-registry.cern.ch/atlas/athena/analysisbase:24.2.0` |
+| Search pattern                              | `find=analysisbase,24.2,alma9`                                   |
+
+Short aliases resolve to CVMFS-hosted Apptainer images. Docker references
+pull from the specified registry.
+
+## Container type detection
+
+setupATLAS auto-detects image type and adjusts behavior:
+
+| Type             | Detection rule                    | setupATLAS inside? |
+| ---------------- | --------------------------------- | ------------------ |
+| atlas-default    | Standard ATLAS base image         | Yes                |
+| atlas-standalone | `/release_setup.sh` exists        | No                 |
+| non-atlas        | Not an ATLAS image                | No                 |
+
+For atlas-standalone images, source the release manually:
+
+```bash
+source /release_setup.sh
+source /alrb/postATLASReleaseSetup.sh
+```
+
+## Mount points
+
+These directories are mounted automatically:
+
+| Host       | Container      | Notes                            |
+| ---------- | -------------- | -------------------------------- |
+| `$TMPDIR`  | `/scratch`     | Temporary storage                |
+| `$PWD`     | `/srv`         | Working directory at entry       |
+| `$HOME`    | `/home/<user>` | Home directory                   |
+| `/cvmfs`   | `/cvmfs`       | CVMFS software repository        |
+
+Add custom mounts via the `-o` flag:
+
+```bash
+# Docker
+setupATLAS -c el9 -o "-v /data/mydata:/data/mydata"
+
+# Apptainer
+setupATLAS -c el9 -o "-B /data/mydata:/data/mydata"
+```
+
+## Login scripts
+
+Container shells source these files (if they exist) instead of the host
+login scripts:
+
+| Shell | File                      |
+| ----- | ------------------------- |
+| bash  | `$HOME/.bashrc.container` |
+| zsh   | `$HOME/.zshrc.container`  |
+| SSH   | `$HOME/.ssh.container`    |
+
+## GPU passthrough examples
+
+```bash
+# Apptainer with NVIDIA GPU
+setupATLAS -c centos7 -e "--nv"
+
+# Docker with NVIDIA GPU
+setupATLAS -c centos7 -e "--gpus all"
+
+# Docker with specific GPUs
+setupATLAS -c centos7 -e "--gpus '\"device=0,1\"'"
+```
+
+## Batch mode
+
+Enter with `-b` to prepare for batch submission:
+
+```bash
+setupATLAS -c centos7 -b
+batchScript "source /path/myJob.sh" -o submitMyJob.sh
+```
+
+Submit the generated script to the local scheduler:
+
+| Scheduler | Command                                |
+| --------- | -------------------------------------- |
+| SLURM     | `sbatch --export=NONE submitMyJob.sh`  |
+| LSF       | `bsub -L /bin/bash submitMyJob.sh`     |
+| HTCondor  | `condor_submit submitMyJob.sub`        |
+
+The `--export=NONE` flag for SLURM prevents host environment leakage into
+the container job.

--- a/plugins/atlas/skills/centralpage/SKILL.md
+++ b/plugins/atlas/skills/centralpage/SKILL.md
@@ -88,8 +88,12 @@ analysis.
 
 ## Interop
 
-- **pyAMI**: Use alongside centralpage for detailed dataset metadata queries —
-  pyAMI has a dedicated MCP server (`ami-mcp`).
+- **ami-mcp**: The AMI MCP server (`ami-mcp`) provides LLM-friendly access to
+  the same PMG cross-section database and dataset metadata that centralpage
+  queries. Prefer `ami-mcp` for programmatic lookups of cross-sections,
+  k-factors, filter efficiencies, and dataset tags within a Claude session — it
+  returns structured results without requiring `lsetup`. Requires `~/.globus`
+  credentials and a valid VOMS proxy (`voms-proxy-init --voms atlas`).
 - **Rucio**: Datasets found via centralpage can be located and downloaded with
   Rucio — Rucio has a dedicated MCP server (`rucio-mcp`).
 - **atlasopenmagic**: The ATLAS Open Magic MCP server can also search for

--- a/plugins/atlas/skills/centralpage/SKILL.md
+++ b/plugins/atlas/skills/centralpage/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: centralpage
+description: >-
+  Use when searching for ATLAS Monte Carlo or data samples: querying the PMG
+  central sample database for MC datasets by process, generator, or campaign,
+  looking up cross-sections and filter efficiencies, or identifying which
+  centrally produced samples are available for a given physics process.
+---
+
+# Central Page
+
+## Overview
+
+The ATLAS Central Page is a tool for finding and querying Monte Carlo and data
+samples in the PMG (Physics Modelling Group) central sample database. It helps
+physicists locate the correct dataset containers for their analyses by searching
+through centrally produced sample catalogs, cross-referencing with AMI for
+dataset metadata.
+
+## When to Use
+
+- Searching for MC samples by physics process, generator, or campaign
+- Looking up cross-sections, k-factors, and filter efficiencies for MC samples
+- Identifying which MC campaigns (mc20, mc21, mc23) have a given process
+- Finding the correct dataset container name for a specific signal or background
+
+## Key Concepts
+
+| Concept                | Notes                                                   |
+| ---------------------- | ------------------------------------------------------- |
+| PMG central database   | Authoritative catalog of centrally produced MC samples   |
+| MC campaign            | Production campaign (mc20, mc21, mc23) with fixed config |
+| Cross-section database | PMG-maintained xsec, k-factor, filter efficiency values  |
+| DSID                   | Dataset ID — unique 6-digit number per MC process config |
+| Generator              | Powheg, Sherpa, MadGraph, Pythia, Herwig, etc.           |
+
+## Canonical Patterns
+
+### Setup and launch
+
+```bash
+setupATLAS
+lsetup centralpage
+
+centralpage                      # interactive mode
+centralpage --help              # show options
+```
+
+### Search for samples
+
+```bash
+# Search by process name
+centralpage search "Ztautau"
+
+# Search by generator
+centralpage search "Sherpa ttbar"
+
+# Filter by MC campaign
+centralpage search "mc23 Powheg Zjets"
+```
+
+### Common queries
+
+- Find all MC samples for a specific process (e.g. ttbar, diboson, Zjets)
+- Find samples matching a specific generator (Powheg, Sherpa, MadGraph)
+- Find samples by MC campaign (mc20, mc21, mc23)
+- Look up cross-sections and filter efficiencies for a DSID
+
+### Verify cross-sections
+
+Always cross-check sample cross-sections against the PMG cross-section database
+before using them in an analysis. The centralpage tool provides direct access to
+these values, but verify against the latest PMG recommendations for your
+analysis.
+
+## Gotchas
+
+- **Grid credentials required**: Full sample listing requires valid ATLAS grid
+  credentials (`voms-proxy-init --voms atlas`).
+- **Campaign coverage varies**: Not all MC campaigns have the same processes
+  available — mc23 may lack samples that exist in mc20.
+- **Cross-section verification**: Always verify cross-sections against the PMG
+  cross-section database; values may be updated between production rounds.
+- **Dataset naming conventions change**: Container naming patterns differ across
+  MC campaigns — do not hardcode dataset name patterns.
+- **All ATLAS energy/momentum values are in MeV**: Cross-sections are in pb, but
+  kinematic values follow ATLAS MeV conventions.
+
+## Interop
+
+- **pyAMI**: Use alongside centralpage for detailed dataset metadata queries —
+  pyAMI has a dedicated MCP server (`ami-mcp`).
+- **Rucio**: Datasets found via centralpage can be located and downloaded with
+  Rucio — Rucio has a dedicated MCP server (`rucio-mcp`).
+- **atlasopenmagic**: The ATLAS Open Magic MCP server can also search for
+  datasets and provides complementary search capabilities.
+- **setupATLAS**: `lsetup centralpage` requires a working ALRB environment — see
+  the setupatlas skill.
+
+Contact: See PMG infrastructure team
+
+## Docs
+
+https://gitlab.cern.ch/atlas-physics/pmg/infrastructure/central-page

--- a/plugins/atlas/skills/centralpage/SKILL.md
+++ b/plugins/atlas/skills/centralpage/SKILL.md
@@ -26,8 +26,8 @@ dataset metadata.
 
 ## Key Concepts
 
-| Concept                | Notes                                                   |
-| ---------------------- | ------------------------------------------------------- |
+| Concept                | Notes                                                    |
+| ---------------------- | -------------------------------------------------------- |
 | PMG central database   | Authoritative catalog of centrally produced MC samples   |
 | MC campaign            | Production campaign (mc20, mc21, mc23) with fixed config |
 | Cross-section database | PMG-maintained xsec, k-factor, filter efficiency values  |

--- a/plugins/atlas/skills/coffea/SKILL.md
+++ b/plugins/atlas/skills/coffea/SKILL.md
@@ -280,51 +280,6 @@ class SystematicsProcessor(ProcessorABC):
         return accumulator
 ```
 
-## Gotchas
-
-- **Schema selection matters for ATLAS**: CP algorithm NTuples (TopCPToolkit,
-  EasyJet) use `NtupleSchema` from `atlas-schema`; DAOD_PHYSLITE uses
-  `PHYSLITESchema`; other flat NTuples use `BaseSchema`. Setting `schema=None`
-  in `Runner` disables NanoEvents entirely and passes raw uproot arrays.
-  Branches are flat or jagged `vector<float>` under `BaseSchema`, not
-  behavior-augmented — no `.pt`, `.eta` shorthand unless you use
-  `PHYSLITESchema` or `NtupleSchema`.
-- **NanoEvents fields are runtime-dynamic**: the available fields depend on the
-  schema and the file content. Always call `events.fields` and
-  `events.<collection>.fields` in a notebook before writing a processor to avoid
-  `AttributeError` on non-existent branches.
-- **All ATLAS branches are in MeV**: divide by 1000 before GeV histograms.
-- **Two execution patterns for ATLAS**: `Runner` +
-  `IterativeExecutor`/`FuturesExecutor` for local execution; `Runner` +
-  `DaskExecutor(client=client)` to scale the same processor to a Dask
-  Distributed cluster with zero processor-code changes — the processor receives
-  the same materialized `ak.Array` objects in all cases, `hist.Hist` works
-  throughout. Check your version with
-  `import coffea; print(coffea.__version__)`.
-- **`preload` / `buffer_cache`**: `preload` bulk-fetches named branches before
-  the processor loop; `buffer_cache` stores raw numpy arrays to avoid
-  re-decompressing on repeated access.
-- **`process()` must return a dict or a nested dict**: accumulators are merged
-  across chunks by the framework.
-- **`postprocess()` is called once** after all chunks are merged — use it for
-  normalization, not per-chunk computation.
-
-## Interop
-
-- **uproot**: `uproot.iterate` feeds data into coffea processors chunk by chunk.
-- **awkward**: All event data inside processors is `ak.Array`; use `ak.firsts`,
-  `ak.pad_none`, `ak.fill_none` for jagged branches.
-- **hist**: The standard accumulator type; fill inside `process()`, merge
-  automatically across chunks.
-- **vector**: `vector.register_awkward()` adds four-vector methods to awkward
-  records before passing to a processor.
-- **atlas-schema**: `NtupleSchema` from the `atlas-schema` package structures CP
-  algorithm NTuples into collections and exposes `events.systematic_names` /
-  `events[variation]` for systematic iteration; install with
-  `pip install atlas-schema` or `pixi add atlas-schema` (conda-forge).
-- **Coffea-Casa**: ATLAS analysis facility at University of Chicago that
-  pre-configures a dask cluster for ATLAS users.
-
 ## Worked Example: Two-region histogram accumulation
 
 ```python
@@ -374,6 +329,51 @@ class TwoRegionProcessor(ProcessorABC):
 | Histograms don't accumulate across files             | Returning a new `hist.Hist` per chunk   | Use `StrCategory(growth=True)` and rely on `accumulate`     |
 | `None` values after `ak.firsts`                      | Events with zero jets                   | Wrap with `ak.fill_none(arr, default_value)`                |
 | `IterativeExecutor` is slow on many files            | Serial execution                        | Switch to `FuturesExecutor(workers=4)` locally              |
+
+## Gotchas
+
+- **Schema selection matters for ATLAS**: CP algorithm NTuples (TopCPToolkit,
+  EasyJet) use `NtupleSchema` from `atlas-schema`; DAOD_PHYSLITE uses
+  `PHYSLITESchema`; other flat NTuples use `BaseSchema`. Setting `schema=None`
+  in `Runner` disables NanoEvents entirely and passes raw uproot arrays.
+  Branches are flat or jagged `vector<float>` under `BaseSchema`, not
+  behavior-augmented — no `.pt`, `.eta` shorthand unless you use
+  `PHYSLITESchema` or `NtupleSchema`.
+- **NanoEvents fields are runtime-dynamic**: the available fields depend on the
+  schema and the file content. Always call `events.fields` and
+  `events.<collection>.fields` in a notebook before writing a processor to avoid
+  `AttributeError` on non-existent branches.
+- **All ATLAS branches are in MeV**: divide by 1000 before GeV histograms.
+- **Two execution patterns for ATLAS**: `Runner` +
+  `IterativeExecutor`/`FuturesExecutor` for local execution; `Runner` +
+  `DaskExecutor(client=client)` to scale the same processor to a Dask
+  Distributed cluster with zero processor-code changes — the processor receives
+  the same materialized `ak.Array` objects in all cases, `hist.Hist` works
+  throughout. Check your version with
+  `import coffea; print(coffea.__version__)`.
+- **`preload` / `buffer_cache`**: `preload` bulk-fetches named branches before
+  the processor loop; `buffer_cache` stores raw numpy arrays to avoid
+  re-decompressing on repeated access.
+- **`process()` must return a dict or a nested dict**: accumulators are merged
+  across chunks by the framework.
+- **`postprocess()` is called once** after all chunks are merged — use it for
+  normalization, not per-chunk computation.
+
+## Interop
+
+- **uproot**: `uproot.iterate` feeds data into coffea processors chunk by chunk.
+- **awkward**: All event data inside processors is `ak.Array`; use `ak.firsts`,
+  `ak.pad_none`, `ak.fill_none` for jagged branches.
+- **hist**: The standard accumulator type; fill inside `process()`, merge
+  automatically across chunks.
+- **vector**: `vector.register_awkward()` adds four-vector methods to awkward
+  records before passing to a processor.
+- **atlas-schema**: `NtupleSchema` from the `atlas-schema` package structures CP
+  algorithm NTuples into collections and exposes `events.systematic_names` /
+  `events[variation]` for systematic iteration; install with
+  `pip install atlas-schema` or `pixi add atlas-schema` (conda-forge).
+- **Coffea-Casa**: ATLAS analysis facility at University of Chicago that
+  pre-configures a dask cluster for ATLAS users.
 
 ## Docs
 

--- a/plugins/atlas/skills/cpp-bindings/SKILL.md
+++ b/plugins/atlas/skills/cpp-bindings/SKILL.md
@@ -18,6 +18,15 @@ Python 3.8+ and offering smaller binary size and faster compile times. In HEP,
 bindings are used to expose ROOT-based code, custom reconstruction algorithms,
 or legacy C++ analysis code to Python without rewriting.
 
+## When to Use
+
+- Exposing a C++ class or function to Python without rewriting it
+- Binding STL containers (`std::vector`, `std::map`) or Eigen arrays to numpy
+- Wrapping ROOT-based reconstruction algorithms or legacy C++ analysis code
+- Choosing between nanobind (faster compile, leaner) and pybind11 (broader
+  ecosystem) for a new project
+- Setting up a CMake build that produces an importable Python extension module
+
 ## Key Concepts
 
 | Feature       | nanobind                             | pybind11            |

--- a/plugins/atlas/skills/decaylanguage/SKILL.md
+++ b/plugins/atlas/skills/decaylanguage/SKILL.md
@@ -25,6 +25,20 @@ complex multi-body decays must be described and inspected.
 - Visualizing a decay tree as a graph for documentation or cross-checks
 - Converting decay descriptors for input to EvtGen, Pythia, or other generators
 
+## Key Concepts
+
+- **DecFile / `.dec` format**: the EvtGen decay descriptor format; each decay is
+  defined as `Decay <particle>\n  <BF> <daughters> <model> <params>;\nEnddecay`.
+- **`DecayMode`**: a single decay mode — branching fraction + list of daughter
+  names + optional amplitude model and parameters.
+- **`DecayChain`**: a tree of `DecayMode` objects rooted at a mother particle;
+  models the full multi-body decay topology.
+- **Descriptor strings**: compact text notation
+  `[B0 -> (D- -> K+ pi- pi-) pi+]cc` used in Gaudi/Gauss job options; `cc` means
+  charge conjugate is implied.
+- **Graphviz rendering**: `DecayChainViewer` converts a chain to a
+  `graphviz.Digraph` for PDF/SVG export.
+
 ## Canonical Patterns
 
 ### Parse a DecFile / EvtGen .dec file

--- a/plugins/atlas/skills/eiclient/SKILL.md
+++ b/plugins/atlas/skills/eiclient/SKILL.md
@@ -26,13 +26,13 @@ stages, from RAW through ESD, AOD, and DAOD.
 
 ## Key Concepts
 
-| Concept         | Notes                                                        |
-| --------------- | ------------------------------------------------------------ |
-| Event Index     | Central catalog of all ATLAS events across processing stages |
-| Event lookup    | Find datasets containing a specific run + event number       |
-| Event picking   | Given a list of run/event pairs, find matching datasets      |
-| Provenance      | Trace an event through RAW → ESD → AOD → DAOD chain         |
-| Run/event pair  | Events are uniquely identified by (run number, event number) |
+| Concept        | Notes                                                        |
+| -------------- | ------------------------------------------------------------ |
+| Event Index    | Central catalog of all ATLAS events across processing stages |
+| Event lookup   | Find datasets containing a specific run + event number       |
+| Event picking  | Given a list of run/event pairs, find matching datasets      |
+| Provenance     | Trace an event through RAW → ESD → AOD → DAOD chain          |
+| Run/event pair | Events are uniquely identified by (run number, event number) |
 
 ## Canonical Patterns
 
@@ -95,9 +95,8 @@ final derivation.
   be slow — batch queries when possible.
 - **Indexing lag**: Not all processing steps are indexed immediately after
   production — recently produced datasets may have incomplete provenance.
-- **All ATLAS energy/momentum values are in MeV**: The Event Index itself
-  stores metadata, not kinematics, but downstream datasets follow ATLAS
-  conventions.
+- **All ATLAS energy/momentum values are in MeV**: The Event Index itself stores
+  metadata, not kinematics, but downstream datasets follow ATLAS conventions.
 
 ## Interop
 
@@ -116,5 +115,4 @@ Contact: See ATLAS Computing documentation
 
 https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndex
 
-Tutorial:
-https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndexPicking
+Tutorial: https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndexPicking

--- a/plugins/atlas/skills/eiclient/SKILL.md
+++ b/plugins/atlas/skills/eiclient/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: eiclient
+description: >-
+  Use when working with the ATLAS Event Index: looking up which dataset contains
+  a specific run/event number, picking events from a list of run/event pairs,
+  tracing event provenance through processing stages (RAW to AOD to DAOD), or
+  listing all events in a dataset.
+---
+
+# Event Index Client
+
+## Overview
+
+The Event Index (EI) client provides command-line access to the ATLAS Event
+Index — a catalog that tracks every event processed by ATLAS. It enables
+event-level lookup, event picking, and provenance queries across all processing
+stages, from RAW through ESD, AOD, and DAOD.
+
+## When to Use
+
+- Finding which dataset contains a specific run/event number
+- Picking a list of events and identifying all datasets that contain them
+- Tracing an event through the full processing chain (provenance)
+- Listing all events in a given dataset
+- Preparing event lists for grid-based event picking with pathena
+
+## Key Concepts
+
+| Concept         | Notes                                                        |
+| --------------- | ------------------------------------------------------------ |
+| Event Index     | Central catalog of all ATLAS events across processing stages |
+| Event lookup    | Find datasets containing a specific run + event number       |
+| Event picking   | Given a list of run/event pairs, find matching datasets      |
+| Provenance      | Trace an event through RAW → ESD → AOD → DAOD chain         |
+| Run/event pair  | Events are uniquely identified by (run number, event number) |
+
+## Canonical Patterns
+
+### Setup
+
+```bash
+setupATLAS
+lsetup eiclient
+```
+
+### Event lookup
+
+Find which datasets contain a specific event:
+
+```bash
+ei_client GetEvent --run 123456 --event 789012
+```
+
+### Event picking
+
+Given a file with run/event pairs, find datasets containing those events:
+
+```bash
+ei_client EventPicking --eventList events.txt --dataType AOD
+```
+
+Event list file format (one run/event pair per line):
+
+```text
+154514 21179
+154514 29736
+154558 448080
+```
+
+### List events in a dataset
+
+```bash
+ei_client GetEvents \
+  --dataset data18_13TeV.00123456.physics_Main.merge.AOD.f1234_m5678
+```
+
+### Provenance query
+
+Trace an event through all processing stages:
+
+```bash
+ei_client GetProvenance --run 123456 --event 789012
+```
+
+This returns the chain of datasets the event passed through, from RAW to the
+final derivation.
+
+## Gotchas
+
+- **Grid credentials required**: A valid VOMS proxy is needed
+  (`voms-proxy-init --voms atlas`).
+- **Both run and event number required**: Event numbering is per-run, so always
+  specify both run number and event number together.
+- **Large event lists take time**: Processing thousands of run/event pairs may
+  be slow — batch queries when possible.
+- **Indexing lag**: Not all processing steps are indexed immediately after
+  production — recently produced datasets may have incomplete provenance.
+- **All ATLAS energy/momentum values are in MeV**: The Event Index itself
+  stores metadata, not kinematics, but downstream datasets follow ATLAS
+  conventions.
+
+## Interop
+
+- **panda/pathena**: Event lists from EI can be fed to pathena's
+  `--eventPickEvtList` option for grid-based event picking.
+- **Rucio**: Use Rucio (or the `rucio-mcp` server) to locate and download
+  datasets identified by EI queries.
+- **pyAMI**: Complements EI — pyAMI provides dataset-level metadata (tags,
+  cross-sections), while EI provides event-level information.
+- **setupATLAS**: `lsetup eiclient` requires a working ALRB environment — see
+  the setupatlas skill.
+
+Contact: See ATLAS Computing documentation
+
+## Docs
+
+https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndex
+
+Tutorial:
+https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndexPicking

--- a/plugins/atlas/skills/lcgenv/SKILL.md
+++ b/plugins/atlas/skills/lcgenv/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: lcgenv
+description: >-
+  Use when setting up standalone LCG (CERN SFT) software packages via lcgenv or
+  views: listing available LCG releases and platforms, configuring individual
+  packages from a specific LCG release, setting up an entire LCG release at once
+  with views, or combining LCG packages with other ATLAS tools like ROOT or
+  rucio.
+---
+
+# lcgenv and views
+
+## Overview
+
+`lcgenv` and `views` are two mechanisms for setting up software from the LCG
+(CERN SFT) stack distributed via CVMFS. `lcgenv` provides fine-grained control,
+allowing individual packages and their dependencies to be configured from a
+specific LCG release. `views` provides a coarse-grained alternative that sets
+up an entire LCG release at once. Both are accessed via `lsetup` after running
+`setupATLAS`.
+
+## When to Use
+
+- Setting up a specific Python, HEP, or math library from an LCG release
+  without loading a full ATLAS release
+- Listing available LCG releases, platforms, and packages
+- Setting up multiple LCG packages with compatible versions from the same
+  release
+- Quickly activating an entire LCG release environment via views
+- Combining LCG packages with standalone ATLAS tools (ROOT, rucio, etc.)
+
+## Key Concepts
+
+**LCG release**: A coordinated software stack (e.g., `LCG_104`) containing
+versioned builds of ROOT, Python, Boost, and hundreds of other packages. Built
+for specific platforms and distributed via `/cvmfs/sft.cern.ch`.
+
+**Platform string**: `<arch>-<os>-<compiler>-<mode>`, e.g.,
+`x86_64-el9-gcc13-opt`. Determines which binary build to use.
+
+**lcgenv vs views**:
+
+| Aspect      | lcgenv                          | views                          |
+| ----------- | ------------------------------- | ------------------------------ |
+| Granularity | Individual packages             | Entire LCG release             |
+| Speed       | Slower (resolves dependencies)  | Faster (single setup)          |
+| Flexibility | Pick only what you need         | All-or-nothing                 |
+| Use case    | Minimal environment, mixing     | Full LCG stack needed          |
+
+## Canonical Patterns
+
+### List available LCG releases
+
+```bash
+lsetup "lcgenv"
+```
+
+### List platforms for a release
+
+```bash
+lsetup "lcgenv -p LCG_104"
+```
+
+### List packages available in a release
+
+```bash
+lsetup "lcgenv -p LCG_104 x86_64-el9-gcc13-opt"
+```
+
+### Set up a single package
+
+```bash
+lsetup "lcgenv -p LCG_104 x86_64-el9-gcc13-opt pyanalysis"
+```
+
+This configures the package and all its dependencies in the current shell.
+
+### Set up multiple packages
+
+Each package must be a separate quoted `lcgenv` invocation:
+
+```bash
+lsetup \
+  "lcgenv -p LCG_104 x86_64-el9-gcc13-opt pygraphics" \
+  "lcgenv -p LCG_104 x86_64-el9-gcc13-opt pyanalysis"
+```
+
+### Combine with other lsetup tools
+
+```bash
+lsetup \
+  "lcgenv -p LCG_104 x86_64-el9-gcc13-opt pyanalysis" \
+  "root 6.32" \
+  rucio
+```
+
+### List available LCG views releases
+
+```bash
+lsetup "views"
+```
+
+### Set up a full LCG release with views
+
+```bash
+lsetup "views LCG_104 x86_64-el9-gcc13-opt"
+```
+
+This activates the entire software stack (ROOT, Python, Boost, etc.) from the
+specified release in one command.
+
+### Check which package version is in a release
+
+```bash
+lsetup "lcgenv -p LCG_104 x86_64-el9-gcc13-opt" | grep -i boost
+```
+
+The output lists all available packages with their versions; grep to find
+a specific one.
+
+### Common packages available via lcgenv
+
+| Package       | Description                            |
+| ------------- | -------------------------------------- |
+| `pyanalysis`  | Python analysis stack (numpy, etc.)    |
+| `pygraphics`  | Plotting libraries (matplotlib, etc.)  |
+| `Boost`       | Boost C++ libraries                    |
+| `eigen`       | Eigen linear algebra library           |
+| `hdf5`        | HDF5 data format library               |
+| `fftw`        | Fast Fourier Transform library         |
+
+## Gotchas
+
+- **`-p` flag required for lcgenv**: The release must be specified with `-p`
+  (e.g., `lcgenv -p LCG_104`), not as a positional argument.
+- **Quoting is mandatory**: `lsetup` arguments with spaces must be quoted —
+  `lsetup "lcgenv -p LCG_104 x86_64-el9-gcc13-opt pkg"`, not
+  `lsetup lcgenv -p LCG_104 ...`.
+- **views is all-or-nothing**: Unlike lcgenv, views does not support selecting
+  individual packages — it loads everything from the release.
+- **CVMFS access required**: Both tools read from `/cvmfs/sft.cern.ch`. Ensure
+  CVMFS is mounted and accessible.
+- **Platform must match the host**: Using a platform string that does not match
+  the running OS (e.g., `slc6` on an EL9 host) produces broken environments.
+  Check with `cat /etc/os-release` if unsure.
+- **Do not mix lcgenv and views in the same shell**: Setting up a views release
+  and then overlaying lcgenv packages from a different release can cause library
+  conflicts.
+- **Older release names**: Historical releases may use `slc6` or `centos7` in
+  platform strings; current platforms use `el9`.
+
+## Interop
+
+- **setupATLAS**: `lsetup` must be available before using `lcgenv` or `views`.
+  Run `setupATLAS` first. See the setupatlas skill.
+- **ROOT**: `lsetup "root 6.32"` sets up ROOT independently. Use lcgenv only
+  when a specific LCG-bundled ROOT version is needed.
+- **asetup**: Full ATLAS releases already include LCG packages. Do not layer
+  lcgenv on top of an asetup environment — use one or the other.
+- **scikit-hep**: `lsetup scikit` provides the scikit-hep ecosystem
+  independently of LCG. Use lcgenv when a specific LCG-coordinated version is
+  required.
+
+## Docs
+
+- lcgenv: https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Lcgenv
+- views: Self-documenting via `lsetup "views"` (lists releases and platforms)
+- LCG releases: https://lcginfo.cern.ch

--- a/plugins/atlas/skills/lcgenv/SKILL.md
+++ b/plugins/atlas/skills/lcgenv/SKILL.md
@@ -15,14 +15,14 @@ description: >-
 `lcgenv` and `views` are two mechanisms for setting up software from the LCG
 (CERN SFT) stack distributed via CVMFS. `lcgenv` provides fine-grained control,
 allowing individual packages and their dependencies to be configured from a
-specific LCG release. `views` provides a coarse-grained alternative that sets
-up an entire LCG release at once. Both are accessed via `lsetup` after running
+specific LCG release. `views` provides a coarse-grained alternative that sets up
+an entire LCG release at once. Both are accessed via `lsetup` after running
 `setupATLAS`.
 
 ## When to Use
 
-- Setting up a specific Python, HEP, or math library from an LCG release
-  without loading a full ATLAS release
+- Setting up a specific Python, HEP, or math library from an LCG release without
+  loading a full ATLAS release
 - Listing available LCG releases, platforms, and packages
 - Setting up multiple LCG packages with compatible versions from the same
   release
@@ -40,12 +40,12 @@ for specific platforms and distributed via `/cvmfs/sft.cern.ch`.
 
 **lcgenv vs views**:
 
-| Aspect      | lcgenv                          | views                          |
-| ----------- | ------------------------------- | ------------------------------ |
-| Granularity | Individual packages             | Entire LCG release             |
-| Speed       | Slower (resolves dependencies)  | Faster (single setup)          |
-| Flexibility | Pick only what you need         | All-or-nothing                 |
-| Use case    | Minimal environment, mixing     | Full LCG stack needed          |
+| Aspect      | lcgenv                         | views                 |
+| ----------- | ------------------------------ | --------------------- |
+| Granularity | Individual packages            | Entire LCG release    |
+| Speed       | Slower (resolves dependencies) | Faster (single setup) |
+| Flexibility | Pick only what you need        | All-or-nothing        |
+| Use case    | Minimal environment, mixing    | Full LCG stack needed |
 
 ## Canonical Patterns
 
@@ -115,19 +115,19 @@ specified release in one command.
 lsetup "lcgenv -p LCG_104 x86_64-el9-gcc13-opt" | grep -i boost
 ```
 
-The output lists all available packages with their versions; grep to find
-a specific one.
+The output lists all available packages with their versions; grep to find a
+specific one.
 
 ### Common packages available via lcgenv
 
-| Package       | Description                            |
-| ------------- | -------------------------------------- |
-| `pyanalysis`  | Python analysis stack (numpy, etc.)    |
-| `pygraphics`  | Plotting libraries (matplotlib, etc.)  |
-| `Boost`       | Boost C++ libraries                    |
-| `eigen`       | Eigen linear algebra library           |
-| `hdf5`        | HDF5 data format library               |
-| `fftw`        | Fast Fourier Transform library         |
+| Package      | Description                           |
+| ------------ | ------------------------------------- |
+| `pyanalysis` | Python analysis stack (numpy, etc.)   |
+| `pygraphics` | Plotting libraries (matplotlib, etc.) |
+| `Boost`      | Boost C++ libraries                   |
+| `eigen`      | Eigen linear algebra library          |
+| `hdf5`       | HDF5 data format library              |
+| `fftw`       | Fast Fourier Transform library        |
 
 ## Gotchas
 

--- a/plugins/atlas/skills/managetier3sw/SKILL.md
+++ b/plugins/atlas/skills/managetier3sw/SKILL.md
@@ -2,30 +2,28 @@
 name: managetier3sw
 description: >-
   Use when installing, updating, or removing ATLAS software on a local Tier-3
-  cluster, laptop, or desktop with manageTier3SW, configuring
-  ATLASLocalRootBase for a non-CVMFS site, running local ATLAS software
-  diagnostics, setting up local post-user scripts, or troubleshooting Tier-3
-  ATLAS software installations.
+  cluster, laptop, or desktop with manageTier3SW, configuring ATLASLocalRootBase
+  for a non-CVMFS site, running local ATLAS software diagnostics, setting up
+  local post-user scripts, or troubleshooting Tier-3 ATLAS software
+  installations.
 ---
 
 # manageTier3SW
 
 ## Overview
 
-manageTier3SW installs, updates, and removes ATLAS software
-(ATLASLocalRootBase, AtlasSetup, PandaClient, ROOT, Rucio, etc.) on laptops,
-desktops, or Tier-3 clusters where CVMFS is not available. It mirrors the CVMFS
-software stack into a local directory managed by a non-privileged account,
-keeping the environment identical to what `setupATLAS` provides on lxplus. If
-CVMFS is available, prefer mounting `/cvmfs/atlas.cern.ch` directly — no local
-install is needed.
+manageTier3SW installs, updates, and removes ATLAS software (ATLASLocalRootBase,
+AtlasSetup, PandaClient, ROOT, Rucio, etc.) on laptops, desktops, or Tier-3
+clusters where CVMFS is not available. It mirrors the CVMFS software stack into
+a local directory managed by a non-privileged account, keeping the environment
+identical to what `setupATLAS` provides on lxplus. If CVMFS is available, prefer
+mounting `/cvmfs/atlas.cern.ch` directly — no local install is needed.
 
 ## When to Use
 
 - Installing ATLAS software locally on a machine without CVMFS
 - Updating or removing ATLAS software versions on a Tier-3 site
-- Configuring local overrides for ALRB (custom post-setup scripts, local
-  config)
+- Configuring local overrides for ALRB (custom post-setup scripts, local config)
 - Running diagnostics to validate a Tier-3 ATLAS software installation
 - Troubleshooting missing RPMs, broken Frontier-squid, or stale tool versions
 
@@ -129,9 +127,9 @@ ls $ATLAS_LOCAL_ROOT_BASE/logDir/installed
 - **Cron job is essential**: Without `updateManageTier3SW.sh` running regularly,
   the installation drifts from the current CVMFS state and accumulates obsolete
   versions.
-- **RPM dependencies**: `checkOS` identifies missing system-level RPMs that ATLAS
-  software requires. Install these with the system package manager (requires root
-  privileges, unlike the ATLAS software itself).
+- **RPM dependencies**: `checkOS` identifies missing system-level RPMs that
+  ATLAS software requires. Install these with the system package manager
+  (requires root privileges, unlike the ATLAS software itself).
 - **Frontier-squid**: `db-fnget` tests the local Frontier-squid proxy used for
   conditions database access. A failed test means conditions data lookups will
   fall back to direct connections or fail entirely.
@@ -139,15 +137,15 @@ ls $ATLAS_LOCAL_ROOT_BASE/logDir/installed
 
 ## Interop
 
-- **setupATLAS**: Once manageTier3SW is installed, `setupATLAS` works identically
-  to CVMFS-based sites — see the setupatlas skill.
+- **setupATLAS**: Once manageTier3SW is installed, `setupATLAS` works
+  identically to CVMFS-based sites — see the setupatlas skill.
 - **CVMFS**: Sites with CVMFS access do not need manageTier3SW; mount
   `/cvmfs/atlas.cern.ch` and source `atlasLocalSetup.sh` directly.
 
-| Domain                   | Contact                                |
-| ------------------------ | -------------------------------------- |
-| Tier-3 software install  | atlas-adc-tier3-managers@cern.ch       |
-| ATLAS software (general) | hn-atlas-offlineSWHelp@cern.ch         |
+| Domain                   | Contact                          |
+| ------------------------ | -------------------------------- |
+| Tier-3 software install  | atlas-adc-tier3-managers@cern.ch |
+| ATLAS software (general) | hn-atlas-offlineSWHelp@cern.ch   |
 
 ## Docs
 

--- a/plugins/atlas/skills/managetier3sw/SKILL.md
+++ b/plugins/atlas/skills/managetier3sw/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: managetier3sw
+description: >-
+  Use when installing, updating, or removing ATLAS software on a local Tier-3
+  cluster, laptop, or desktop with manageTier3SW, configuring
+  ATLASLocalRootBase for a non-CVMFS site, running local ATLAS software
+  diagnostics, setting up local post-user scripts, or troubleshooting Tier-3
+  ATLAS software installations.
+---
+
+# manageTier3SW
+
+## Overview
+
+manageTier3SW installs, updates, and removes ATLAS software
+(ATLASLocalRootBase, AtlasSetup, PandaClient, ROOT, Rucio, etc.) on laptops,
+desktops, or Tier-3 clusters where CVMFS is not available. It mirrors the CVMFS
+software stack into a local directory managed by a non-privileged account,
+keeping the environment identical to what `setupATLAS` provides on lxplus. If
+CVMFS is available, prefer mounting `/cvmfs/atlas.cern.ch` directly — no local
+install is needed.
+
+## When to Use
+
+- Installing ATLAS software locally on a machine without CVMFS
+- Updating or removing ATLAS software versions on a Tier-3 site
+- Configuring local overrides for ALRB (custom post-setup scripts, local
+  config)
+- Running diagnostics to validate a Tier-3 ATLAS software installation
+- Troubleshooting missing RPMs, broken Frontier-squid, or stale tool versions
+
+## Key Concepts
+
+**Non-privileged account**: Install under a dedicated service account (e.g.
+`atlasadmin`). manageTier3SW only modifies the `atlasadmin` home directory and
+`$ATLAS_LOCAL_ROOT_BASE` — no root privileges required for the software itself.
+
+**ATLAS_LOCAL_ROOT_BASE**: The root of the local ATLAS software tree. All tools,
+releases, and configuration live under this path. Set this environment variable
+before sourcing `atlasLocalSetup.sh`.
+
+**Custom content naming**: Any locally created content (scripts, configs, tool
+wrappers) must use names beginning with `local` to avoid conflicts with upstream
+updates.
+
+**Automatic cleanup**: The `updateManageTier3SW.sh` cron job auto-removes
+obsolete software versions during updates, keeping the installation current
+without manual intervention.
+
+## Canonical Patterns
+
+### Initial Installation
+
+Install in a dedicated non-privileged account:
+
+```bash
+# As the atlasadmin user
+cd /path/to/atlasadmin
+# Follow the manageTier3SW installation instructions for your OS
+# The installer populates $ATLAS_LOCAL_ROOT_BASE
+```
+
+### Keeping Software Up to Date
+
+Schedule `updateManageTier3SW.sh` as a daily cron job to pull new releases and
+remove obsolete versions automatically:
+
+```bash
+# crontab entry (as atlasadmin)
+0 3 * * * /path/to/updateManageTier3SW.sh
+```
+
+### Local Configuration Overrides
+
+Create a local config directory to customize ALRB behavior without modifying
+upstream files:
+
+```bash
+mkdir -p /path/to/localConfig
+cp $ATLAS_LOCAL_ROOT_BASE/exampleLocalConfig/* /path/to/localConfig/
+export ALRB_localConfigDir=/path/to/localConfig
+```
+
+### Post-Setup Scripts
+
+Create site-wide scripts that run after every user's `setupATLAS` call. Place
+them in `$ATLAS_LOCAL_ROOT_BASE/config`:
+
+```bash
+# $ATLAS_LOCAL_ROOT_BASE/config/localPostUserSetup.sh
+# This runs after every setupATLAS invocation on this site
+export MY_SITE_VAR="custom_value"
+```
+
+Users can bypass post-setup scripts when needed:
+
+```bash
+setupATLAS --noLocalPostSetup
+```
+
+### Running Diagnostics
+
+Validate the full installation after setup or updates:
+
+```bash
+setupATLAS
+diagnostics                                # interactive diagnostics menu
+checkOS                                    # verify required RPMs are installed
+db-fnget                                   # test Frontier-squid connectivity
+toolTest -m validate all -T                # validate all installed tools
+```
+
+### Checking Installation Logs
+
+Review what was installed and when:
+
+```bash
+ls $ATLAS_LOCAL_ROOT_BASE/logDir/installed
+```
+
+## Gotchas
+
+- **CVMFS preferred**: If `/cvmfs/atlas.cern.ch` is mountable, use it directly
+  instead of manageTier3SW — CVMFS is self-updating and requires no local
+  maintenance.
+- **Custom names must start with `local`**: Any user-created files or scripts in
+  the managed tree must be prefixed with `local` to prevent upstream updates
+  from overwriting them.
+- **Cron job is essential**: Without `updateManageTier3SW.sh` running regularly,
+  the installation drifts from the current CVMFS state and accumulates obsolete
+  versions.
+- **RPM dependencies**: `checkOS` identifies missing system-level RPMs that ATLAS
+  software requires. Install these with the system package manager (requires root
+  privileges, unlike the ATLAS software itself).
+- **Frontier-squid**: `db-fnget` tests the local Frontier-squid proxy used for
+  conditions database access. A failed test means conditions data lookups will
+  fall back to direct connections or fail entirely.
+- **All ATLAS energy/momentum values are in MeV**.
+
+## Interop
+
+- **setupATLAS**: Once manageTier3SW is installed, `setupATLAS` works identically
+  to CVMFS-based sites — see the setupatlas skill.
+- **CVMFS**: Sites with CVMFS access do not need manageTier3SW; mount
+  `/cvmfs/atlas.cern.ch` and source `atlasLocalSetup.sh` directly.
+
+| Domain                   | Contact                                |
+| ------------------------ | -------------------------------------- |
+| Tier-3 software install  | atlas-adc-tier3-managers@cern.ch       |
+| ATLAS software (general) | hn-atlas-offlineSWHelp@cern.ch         |
+
+## Docs
+
+https://twiki.atlas-canada.ca/bin/view/AtlasCanada/ManageTier3SW

--- a/plugins/atlas/skills/mplhep/SKILL.md
+++ b/plugins/atlas/skills/mplhep/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: mplhep
 description: >-
-  Use when creating ATLAS publication-quality plots with matplotlib using mplhep:
-  applying the ATLAS experiment style, placing ATLAS labels (Internal,
+  Use when creating ATLAS publication-quality plots with matplotlib using
+  mplhep: applying the ATLAS experiment style, placing ATLAS labels (Internal,
   Preliminary, Simulation), plotting 1D or 2D histograms from hist/uproot/numpy,
   making data/MC comparison plots with ratio panels, using mplhep comparison
   functions (ratio, pull, split_ratio), or customizing ATLAS label positions and
@@ -32,32 +32,32 @@ plotters for data/MC ratio panels. For ATLAS work, `mplhep` replaces the ROOT
 
 ## Key Concepts
 
-| Function / Module         | Purpose                                               |
-| ------------------------- | ----------------------------------------------------- |
-| `mh.style.use("ATLAS")`  | Apply the ATLAS matplotlib style globally             |
-| `mh.atlas.label()`       | Place official ATLAS label with status, lumi, com     |
-| `mh.histplot()`          | Plot 1D histograms (step, fill, errorbar, band, bar)  |
-| `mh.hist2dplot()`        | Plot 2D histograms with optional colorbar             |
-| `mh.comp.hists()`        | Compare two histograms with a ratio/pull panel        |
-| `mh.comp.data_model()`   | Data vs stacked MC with comparison panel              |
-| `mh.comp.comparison()`   | Standalone comparison panel (no main plot)             |
-| `mh.mpl_magic()`         | Auto-fit y-axis for labels and legends                |
-| `mh.add_text()`          | Place arbitrary text at named locations                |
-| `mh.savelabels()`        | Generate plot variations (Preliminary, Final, WIP)    |
-| `mh.subplots()`          | Multi-panel figure with automatic sizing              |
+| Function / Module       | Purpose                                              |
+| ----------------------- | ---------------------------------------------------- |
+| `mh.style.use("ATLAS")` | Apply the ATLAS matplotlib style globally            |
+| `mh.atlas.label()`      | Place official ATLAS label with status, lumi, com    |
+| `mh.histplot()`         | Plot 1D histograms (step, fill, errorbar, band, bar) |
+| `mh.hist2dplot()`       | Plot 2D histograms with optional colorbar            |
+| `mh.comp.hists()`       | Compare two histograms with a ratio/pull panel       |
+| `mh.comp.data_model()`  | Data vs stacked MC with comparison panel             |
+| `mh.comp.comparison()`  | Standalone comparison panel (no main plot)           |
+| `mh.mpl_magic()`        | Auto-fit y-axis for labels and legends               |
+| `mh.add_text()`         | Place arbitrary text at named locations              |
+| `mh.savelabels()`       | Generate plot variations (Preliminary, Final, WIP)   |
+| `mh.subplots()`         | Multi-panel figure with automatic sizing             |
 
 ### ATLAS Label Categories
 
 Label text follows ATLAS publication policy (identical to the ROOT
 `atlasrootstyle` macros covered by the astyle skill):
 
-| Status text           | Usage                                  |
-| --------------------- | -------------------------------------- |
-| `""`                  | Approved results in published papers   |
-| `"Preliminary"`       | Conference results not yet in a paper  |
-| `"Internal"`          | Results not for public distribution    |
-| `"Simulation"`        | Simulation-only results (no real data) |
-| `"Work in Progress"`  | Early-stage results, not for approval  |
+| Status text          | Usage                                  |
+| -------------------- | -------------------------------------- |
+| `""`                 | Approved results in published papers   |
+| `"Preliminary"`      | Conference results not yet in a paper  |
+| `"Internal"`         | Results not for public distribution    |
+| `"Simulation"`       | Simulation-only results (no real data) |
+| `"Work in Progress"` | Early-stage results, not for approval  |
 
 ### Supported Input Formats
 
@@ -185,17 +185,17 @@ fig, ax_main, ax_comp = mh.comp.data_model(
 - **ATLAS luminosity format defaults to integer**: `lumi_format="{0:.0f}"`, so
   `lumi=140` renders as "140 fb^{-1}". Override with `lumi_format="{0:.1f}"` if
   decimal precision is needed.
-- **Automatic error bars with `hist.Hist`**: When a histogram has
-  `.variances()` (i.e. `Weight()` storage), `histplot` shows error bars
-  automatically. Numpy histogram tuples do not carry variance information.
+- **Automatic error bars with `hist.Hist`**: When a histogram has `.variances()`
+  (i.e. `Weight()` storage), `histplot` shows error bars automatically. Numpy
+  histogram tuples do not carry variance information.
 - **`mh.hist()` does not return UHI objects**: Unlike `mh.histplot()`, the
   convenience wrapper `mh.hist()` runs `np.histogram` internally and cannot be
   used with other mplhep histogram functions.
 - **All ATLAS energy/momentum values are in MeV** in the detector/analysis
   framework, but plot axis labels conventionally show GeV or TeV. Divide by 1000
   before filling histograms.
-- **Style is a dict**: Access as `mh.style.ATLAS` to inspect or extend
-  rcParams. Customize via `mh.style.use([mh.style.ATLAS, {"font.size": 14}])`.
+- **Style is a dict**: Access as `mh.style.ATLAS` to inspect or extend rcParams.
+  Customize via `mh.style.use([mh.style.ATLAS, {"font.size": 14}])`.
 
 ## Interop
 

--- a/plugins/atlas/skills/mplhep/SKILL.md
+++ b/plugins/atlas/skills/mplhep/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: mplhep
+description: >-
+  Use when creating ATLAS publication-quality plots with matplotlib using mplhep:
+  applying the ATLAS experiment style, placing ATLAS labels (Internal,
+  Preliminary, Simulation), plotting 1D or 2D histograms from hist/uproot/numpy,
+  making data/MC comparison plots with ratio panels, using mplhep comparison
+  functions (ratio, pull, split_ratio), or customizing ATLAS label positions and
+  luminosity text on matplotlib figures.
+---
+
+# mplhep -- Matplotlib for HEP
+
+## Overview
+
+`mplhep` is the scikit-hep matplotlib wrapper for publication-quality HEP plots.
+It provides experiment-specific styles (ATLAS, CMS, LHCb, ALICE, DUNE),
+histogram plotting functions that accept `hist.Hist`, `uproot.TH1`, and numpy
+arrays via the Unified Histogram Interface (UHI), and dedicated comparison
+plotters for data/MC ratio panels. For ATLAS work, `mplhep` replaces the ROOT
+`atlasrootstyle` macros with a pure-Python matplotlib workflow.
+
+## When to Use
+
+- Creating ATLAS publication-quality plots in matplotlib (not ROOT)
+- Applying the ATLAS experiment style (`mplhep.style.use("ATLAS")`)
+- Placing ATLAS labels (Internal, Preliminary, Simulation) on matplotlib figures
+- Plotting prebinned histograms from `hist.Hist`, `uproot.TH1`, or numpy arrays
+- Making data/MC comparison plots with ratio, pull, or split-ratio panels
+- Customizing ATLAS label positions, luminosity text, and center-of-mass energy
+- Using `mplhep.comp.data_model()` for stacked background + signal + data plots
+
+## Key Concepts
+
+| Function / Module         | Purpose                                               |
+| ------------------------- | ----------------------------------------------------- |
+| `mh.style.use("ATLAS")`  | Apply the ATLAS matplotlib style globally             |
+| `mh.atlas.label()`       | Place official ATLAS label with status, lumi, com     |
+| `mh.histplot()`          | Plot 1D histograms (step, fill, errorbar, band, bar)  |
+| `mh.hist2dplot()`        | Plot 2D histograms with optional colorbar             |
+| `mh.comp.hists()`        | Compare two histograms with a ratio/pull panel        |
+| `mh.comp.data_model()`   | Data vs stacked MC with comparison panel              |
+| `mh.comp.comparison()`   | Standalone comparison panel (no main plot)             |
+| `mh.mpl_magic()`         | Auto-fit y-axis for labels and legends                |
+| `mh.add_text()`          | Place arbitrary text at named locations                |
+| `mh.savelabels()`        | Generate plot variations (Preliminary, Final, WIP)    |
+| `mh.subplots()`          | Multi-panel figure with automatic sizing              |
+
+### ATLAS Label Categories
+
+Label text follows ATLAS publication policy (identical to the ROOT
+`atlasrootstyle` macros covered by the astyle skill):
+
+| Status text           | Usage                                  |
+| --------------------- | -------------------------------------- |
+| `""`                  | Approved results in published papers   |
+| `"Preliminary"`       | Conference results not yet in a paper  |
+| `"Internal"`          | Results not for public distribution    |
+| `"Simulation"`        | Simulation-only results (no real data) |
+| `"Work in Progress"`  | Early-stage results, not for approval  |
+
+### Supported Input Formats
+
+`mh.histplot()` accepts any UHI-compatible histogram:
+
+- **`hist.Hist`** -- error bars shown automatically when `Weight()` storage is
+  used (has `.variances()`)
+- **`uproot.TH1`** -- ROOT histograms read via uproot, plotted directly
+- **`numpy.histogram` tuple** -- `(values, bin_edges)` from `np.histogram()`
+- **Array-like** -- plain list or array of bin heights (bins auto-generated)
+
+## Canonical Patterns
+
+### Minimal ATLAS Histogram
+
+```python
+import matplotlib.pyplot as plt
+import mplhep as mh
+import numpy as np
+
+mh.style.use("ATLAS")
+
+fig, ax = plt.subplots()
+mh.histplot(*np.histogram(np.random.normal(0, 1, 1000), bins=40), ax=ax)
+mh.atlas.label("Internal", data=False, lumi=150, com=13)
+mh.mpl_magic(soft_fail=True)
+fig.savefig("plot.pdf")
+```
+
+### Plotting a hist.Hist Object
+
+```python
+import matplotlib.pyplot as plt
+import hist
+import mplhep as mh
+
+mh.style.use("ATLAS")
+
+h = hist.Hist(hist.axis.Regular(50, 0, 500, name="pt", label=r"$p_T$ [GeV]"))
+h.fill(pt=jet_pts_gev, weight=event_weights)  # user-provided arrays
+
+fig, ax = plt.subplots()
+mh.histplot(h, ax=ax, histtype="errorbar", label="Data")
+mh.atlas.label("Internal", data=True, lumi=150, com=13)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Stacked Backgrounds with Data Overlay
+
+```python
+mh.style.use("ATLAS")
+fig, ax = plt.subplots()
+
+mh.histplot(
+    [h_bkg1, h_bkg2, h_signal],
+    histtype="fill",
+    stack=True,
+    label=["Bkg 1", "Bkg 2", "Signal"],
+    ax=ax,
+)
+mh.histplot(h_data, histtype="errorbar", label="Data", ax=ax, color="black")
+ax.legend(loc="upper right")
+mh.atlas.label("Internal", data=True, lumi=150, com=13)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Data/MC Comparison with Ratio Panel
+
+```python
+mh.style.use("ATLAS")
+
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2, h_signal],
+    stacked_labels=["Bkg 1", "Bkg 2", "Signal"],
+    xlabel=r"$m_{jj}$ [GeV]",
+    ylabel="Events",
+)
+mh.atlas.label("Internal", data=True, lumi=150, ax=ax_main)
+mh.mpl_magic(soft_fail=True)
+```
+
+The default comparison is `split_ratio`. Other options: `ratio`, `pull`,
+`difference`, `relative_difference`, `asymmetry`, `efficiency`.
+
+### Two-Histogram Comparison
+
+```python
+fig, ax_main, ax_comp = mh.comp.hists(
+    h1, h2,
+    comparison="ratio",
+    xlabel=r"$m_{jj}$ [GeV]",
+    ylabel="Events",
+    h1_label="Data",
+    h2_label="MC",
+)
+mh.atlas.label("Internal", data=True, ax=ax_main)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Blinding a Signal Region
+
+```python
+mh.histplot(h_data, ax=ax, blind=(-1.0, 1.0), label="Data")
+
+# Also works in comp functions:
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2],
+    stacked_labels=["Bkg 1", "Bkg 2"],
+    blind=(120, 130),
+)
+```
+
+## Gotchas
+
+- **Always call `mh.mpl_magic(soft_fail=True)` after `mh.atlas.label()`**: The
+  ATLAS style requires this to auto-fit the y-axis around labels and legends.
+  Other experiments (CMS, DUNE) do not need it.
+- **Apply style at script top, not per-function**: `mh.style.use("ATLAS")` sets
+  global `rcParams`. Call it once before creating any figures.
+- **`plt.style.context()` is unreliable**: Due to matplotlib font-handling
+  limitations, context managers do not work reliably with mplhep styles. Use
+  `mh.style.use()` globally.
+- **ATLAS luminosity format defaults to integer**: `lumi_format="{0:.0f}"`, so
+  `lumi=140` renders as "140 fb^{-1}". Override with `lumi_format="{0:.1f}"` if
+  decimal precision is needed.
+- **Automatic error bars with `hist.Hist`**: When a histogram has
+  `.variances()` (i.e. `Weight()` storage), `histplot` shows error bars
+  automatically. Numpy histogram tuples do not carry variance information.
+- **`mh.hist()` does not return UHI objects**: Unlike `mh.histplot()`, the
+  convenience wrapper `mh.hist()` runs `np.histogram` internally and cannot be
+  used with other mplhep histogram functions.
+- **All ATLAS energy/momentum values are in MeV** in the detector/analysis
+  framework, but plot axis labels conventionally show GeV or TeV. Divide by 1000
+  before filling histograms.
+- **Style is a dict**: Access as `mh.style.ATLAS` to inspect or extend
+  rcParams. Customize via `mh.style.use([mh.style.ATLAS, {"font.size": 14}])`.
+
+## Interop
+
+- **astyle (ROOT)**: The astyle skill covers the ROOT `atlasrootstyle` macros
+  (`SetAtlasStyle`, `ATLASLabel`, `myText`). Use mplhep for matplotlib-based
+  ATLAS plots and `atlasrootstyle` for ROOT/PyROOT-based plots. The label
+  categories and publication policy rules are identical across both tools.
+- **hist**: `mh.histplot()` accepts `hist.Hist` objects natively. Use `hist` for
+  histogram creation, slicing, and rebinning; pass directly to mplhep for
+  plotting.
+- **uproot**: `mh.histplot()` accepts `uproot.TH1` objects directly -- read ROOT
+  files with uproot and plot without conversion.
+- **coffea**: Coffea processors accumulate `hist.Hist` objects which plot
+  directly with mplhep.
+- **boost-histogram**: `mh.histplot()` accepts `bh.Histogram` via UHI.
+- **Other experiment styles**: mplhep also supports CMS (`mh.style.use("CMS")`),
+  LHCb (`mh.style.use("LHCb2")`), ALICE, and DUNE styles with matching label
+  functions (`mh.cms.label()`, `mh.lhcb.label()`, etc.).
+
+## Docs
+
+https://mplhep.readthedocs.io/
+
+For detailed reference beyond the upstream docs, consult the bundled files:
+
+- **`references/atlas-label-options.md`** -- Full ATLAS label parameter
+  reference, label positions, text placement, and savelabels workflow
+- **`references/comparison-plots.md`** -- All comparison types with formulas,
+  data/MC patterns, blinding syntax, and custom multi-panel layouts

--- a/plugins/atlas/skills/mplhep/references/atlas-label-options.md
+++ b/plugins/atlas/skills/mplhep/references/atlas-label-options.md
@@ -20,13 +20,13 @@ mh.atlas.label(
 
 ## Label Positions (loc parameter)
 
-| loc | Description                                                   |
-| --- | ------------------------------------------------------------- |
-| 0   | Above axes (default) -- left-aligned, outside the plot frame  |
-| 1   | Top-left corner, single line -- compact inline format         |
-| 2   | Top-left corner, multiline -- stacked label lines             |
-| 3   | Split layout -- experiment name above, secondary text inside  |
-| 4   | ATLAS-specific -- luminosity placed below the main label      |
+| loc | Description                                                  |
+| --- | ------------------------------------------------------------ |
+| 0   | Above axes (default) -- left-aligned, outside the plot frame |
+| 1   | Top-left corner, single line -- compact inline format        |
+| 2   | Top-left corner, multiline -- stacked label lines            |
+| 3   | Split layout -- experiment name above, secondary text inside |
+| 4   | ATLAS-specific -- luminosity placed below the main label     |
 
 ### Position Examples
 
@@ -117,8 +117,7 @@ txt_obj = mh.add_text("Custom annotation", loc="upper left", ax=ax)
 ```
 
 **loc string options**: `"upper left"`, `"upper right"`, `"lower left"`,
-`"lower right"`, `"over left"`, `"over right"`, `"under left"`,
-`"under right"`
+`"lower right"`, `"over left"`, `"over right"`, `"under left"`, `"under right"`
 
 Alternative positioning via `x` and `y` keyword arguments:
 

--- a/plugins/atlas/skills/mplhep/references/atlas-label-options.md
+++ b/plugins/atlas/skills/mplhep/references/atlas-label-options.md
@@ -1,0 +1,175 @@
+# ATLAS Label Options Reference
+
+## mh.atlas.label() Full Parameter Reference
+
+```python
+mh.atlas.label(
+    status,                   # "Internal", "Preliminary", "Simulation", "Work in Progress", or ""
+    data=True,               # whether real data is shown (affects luminosity line)
+    lumi=150,                # integrated luminosity in fb⁻¹
+    com=13,                  # center-of-mass energy in TeV
+    year="2023",             # data-taking year (optional)
+    lumi_format="{0:.0f}",   # luminosity number format (ATLAS default: integer)
+    loc=0,                   # label position (0--4)
+    ax=ax,                   # matplotlib axis (defaults to current)
+    llabel="...",            # custom left label (overrides status)
+    rlabel="...",            # custom right label (overrides lumi/com)
+    supp="arXiv:2024.12345", # supplementary material reference
+)
+```
+
+## Label Positions (loc parameter)
+
+| loc | Description                                                   |
+| --- | ------------------------------------------------------------- |
+| 0   | Above axes (default) -- left-aligned, outside the plot frame  |
+| 1   | Top-left corner, single line -- compact inline format         |
+| 2   | Top-left corner, multiline -- stacked label lines             |
+| 3   | Split layout -- experiment name above, secondary text inside  |
+| 4   | ATLAS-specific -- luminosity placed below the main label      |
+
+### Position Examples
+
+```python
+# Default (above axes)
+mh.atlas.label("Preliminary", data=True, lumi=150, com=13, loc=0)
+
+# Compact single-line in corner
+mh.atlas.label("Preliminary", data=True, lumi=150, com=13, loc=1)
+
+# Multiline in corner
+mh.atlas.label("Preliminary", data=True, lumi=150, com=13, loc=2)
+
+# Split: "ATLAS" above axes, rest in corner
+mh.atlas.label("Preliminary", data=True, lumi=150, com=13, loc=3)
+
+# ATLAS-specific layout with luminosity below
+mh.atlas.label("Preliminary", data=True, lumi=150, com=13, loc=4)
+```
+
+## Common ATLAS Label Configurations
+
+### Standard Internal Plot
+
+```python
+mh.atlas.label("Internal", data=True, lumi=150, com=13)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Conference Preliminary
+
+```python
+mh.atlas.label(
+    "Preliminary",
+    data=True,
+    year="2023",
+    lumi=150,
+    com=13,
+    lumi_format="{0:.0f}",
+)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Published Paper (No Status Text)
+
+```python
+mh.atlas.label("", data=True, lumi=140, com=13)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Simulation-Only
+
+```python
+mh.atlas.label("Simulation", data=False, com=13)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Fully Custom Labels
+
+Override the default layout with `llabel` and `rlabel`:
+
+```python
+mh.atlas.label(llabel="Left Label", rlabel="Right Label")
+mh.mpl_magic(soft_fail=True)
+```
+
+### With Supplementary Material Reference
+
+```python
+mh.atlas.label(
+    "Preliminary",
+    data=True,
+    lumi=150,
+    com=13,
+    supp="arXiv:2024.12345",
+)
+mh.mpl_magic(soft_fail=True)
+```
+
+## Text Placement Utilities
+
+### mh.add_text()
+
+Place arbitrary text at named locations on the axis:
+
+```python
+txt_obj = mh.add_text("Custom annotation", loc="upper left", ax=ax)
+```
+
+**loc string options**: `"upper left"`, `"upper right"`, `"lower left"`,
+`"lower right"`, `"over left"`, `"over right"`, `"under left"`,
+`"under right"`
+
+Alternative positioning via `x` and `y` keyword arguments:
+
+- **x**: `"left_in"`, `"left"`, `"left_out"`, `"right_in"`, `"right"`,
+  `"right_out"`
+- **y**: `"top_in"`, `"top_out"`, `"bottom_in"`, `"bottom_out"`
+
+```python
+mh.add_text("Custom text", x="right_in", y="top_in", ax=ax)
+```
+
+### mh.append_text()
+
+Append text relative to an existing text object:
+
+```python
+txt = mh.add_text("Primary text", loc="upper right", ax=ax)
+mh.append_text("Secondary info", txt, loc="below")
+```
+
+**Relative positions**: `"above"`, `"below"`, `"left"`, `"right"`
+
+## Saving Label Variations with mh.savelabels()
+
+Automatically generate multiple versions of a plot with different label text:
+
+```python
+# Produces: plot.pdf, plot_pas.png, plot_supp.png, plot_wip.png
+mh.savelabels("plot.pdf")
+
+# Custom variations
+mh.savelabels("plot", labels=[("Internal", "internal.pdf"), ("", "final.pdf")])
+```
+
+## Style Customization
+
+### Inspect ATLAS Style Dictionary
+
+```python
+import mplhep as mh
+print(mh.style.ATLAS)
+```
+
+### Extend with Custom rcParams
+
+```python
+mh.style.use([mh.style.ATLAS, {"font.size": 14, "axes.linewidth": 1.5}])
+```
+
+### Reset to Default
+
+```python
+mh.style.use()
+```

--- a/plugins/atlas/skills/mplhep/references/comparison-plots.md
+++ b/plugins/atlas/skills/mplhep/references/comparison-plots.md
@@ -5,14 +5,14 @@
 All comparison functions in `mh.comp` accept a `comparison` parameter with the
 following options:
 
-| Type                  | Formula                                                          |
-| --------------------- | ---------------------------------------------------------------- |
-| `ratio`               | h1 / h2                                                         |
-| `split_ratio`         | h1 / h2 (uncertainties of h1 and h2 shown separately)           |
-| `pull`                | (h1 - h2) / sqrt(sigma_h1^2 + sigma_h2^2)                      |
-| `difference`          | h1 - h2                                                         |
-| `relative_difference` | (h1 - h2) / h2                                                  |
-| `asymmetry`           | (h1 - h2) / (h1 + h2)                                           |
+| Type                  | Formula                                                                  |
+| --------------------- | ------------------------------------------------------------------------ |
+| `ratio`               | h1 / h2                                                                  |
+| `split_ratio`         | h1 / h2 (uncertainties of h1 and h2 shown separately)                    |
+| `pull`                | (h1 - h2) / sqrt(sigma_h1^2 + sigma_h2^2)                                |
+| `difference`          | h1 - h2                                                                  |
+| `relative_difference` | (h1 - h2) / h2                                                           |
+| `asymmetry`           | (h1 - h2) / (h1 + h2)                                                    |
 | `efficiency`          | h1 / h2 (with proper uncertainty propagation from arXiv:physics/0701199) |
 
 ## mh.comp.hists() -- Two-Histogram Comparison
@@ -178,16 +178,16 @@ panel.
 
 ### Blinding Syntax
 
-| Format                        | Description                         |
-| ----------------------------- | ----------------------------------- |
-| `(-1.0, 1.0)`                | Value-based tuple                   |
-| `"-1j:1j"`                   | String with j suffix for values     |
-| `loc[-1.0:1.0]`              | loc slice notation                  |
-| `19`                          | Single bin index                    |
-| `"15:25"`                     | Range of bin indices                |
-| `[18, 19, 20, 21, 22]`       | List of specific bin indices        |
-| `[(-2.5, -1.5), (1.5, 2.5)]` | Multiple value-based regions        |
-| `"5:1j"`                      | Mixed: index start, value end       |
+| Format                       | Description                     |
+| ---------------------------- | ------------------------------- |
+| `(-1.0, 1.0)`                | Value-based tuple               |
+| `"-1j:1j"`                   | String with j suffix for values |
+| `loc[-1.0:1.0]`              | loc slice notation              |
+| `19`                         | Single bin index                |
+| `"15:25"`                    | Range of bin indices            |
+| `[18, 19, 20, 21, 22]`       | List of specific bin indices    |
+| `[(-2.5, -1.5), (1.5, 2.5)]` | Multiple value-based regions    |
+| `"5:1j"`                     | Mixed: index start, value end   |
 
 ### Blinding in comp.hists()
 
@@ -268,32 +268,32 @@ mh.mpl_magic(soft_fail=True)
 
 ## Histogram Types for histplot
 
-| histtype    | Description                                              |
-| ----------- | -------------------------------------------------------- |
-| `"step"`    | Step line histogram (default)                            |
-| `"fill"`    | Filled histogram                                         |
-| `"errorbar"`| Data points with error bars                              |
-| `"band"`    | Uncertainty band (useful for visualizing errors)         |
-| `"bar"`     | Side-by-side bars when multiple histograms are given     |
-| `"barstep"` | Side-by-side step bars for multiple histograms           |
+| histtype     | Description                                          |
+| ------------ | ---------------------------------------------------- |
+| `"step"`     | Step line histogram (default)                        |
+| `"fill"`     | Filled histogram                                     |
+| `"errorbar"` | Data points with error bars                          |
+| `"band"`     | Uncertainty band (useful for visualizing errors)     |
+| `"bar"`      | Side-by-side bars when multiple histograms are given |
+| `"barstep"`  | Side-by-side step bars for multiple histograms       |
 
 ## Normalization Options
 
-| Parameter   | Effect                                  |
-| ----------- | --------------------------------------- |
-| (default)   | Raw event counts                        |
-| `density=True` | Normalized so integral equals 1      |
-| `binwnorm=True`| Divided by bin width (Events / unit) |
+| Parameter       | Effect                               |
+| --------------- | ------------------------------------ |
+| (default)       | Raw event counts                     |
+| `density=True`  | Normalized so integral equals 1      |
+| `binwnorm=True` | Divided by bin width (Events / unit) |
 
 ## Error Bar Control
 
-| Parameter                       | Effect                                      |
-| ------------------------------- | ------------------------------------------- |
-| `yerr=True`                     | Automatic errors (Poisson or from variance) |
-| `yerr=custom_array`             | Explicit error values                       |
-| `w2method="sqrt"`               | sqrt of sum of weights squared              |
-| `w2method="poisson"`            | Poisson interval                            |
-| `w2method=callable`             | Custom function `f(weights, variances)`     |
+| Parameter            | Effect                                      |
+| -------------------- | ------------------------------------------- |
+| `yerr=True`          | Automatic errors (Poisson or from variance) |
+| `yerr=custom_array`  | Explicit error values                       |
+| `w2method="sqrt"`    | sqrt of sum of weights squared              |
+| `w2method="poisson"` | Poisson interval                            |
+| `w2method=callable`  | Custom function `f(weights, variances)`     |
 
 ## Stacking and Sorting
 

--- a/plugins/atlas/skills/mplhep/references/comparison-plots.md
+++ b/plugins/atlas/skills/mplhep/references/comparison-plots.md
@@ -1,0 +1,308 @@
+# Comparison Plots Reference
+
+## Comparison Types
+
+All comparison functions in `mh.comp` accept a `comparison` parameter with the
+following options:
+
+| Type                  | Formula                                                          |
+| --------------------- | ---------------------------------------------------------------- |
+| `ratio`               | h1 / h2                                                         |
+| `split_ratio`         | h1 / h2 (uncertainties of h1 and h2 shown separately)           |
+| `pull`                | (h1 - h2) / sqrt(sigma_h1^2 + sigma_h2^2)                      |
+| `difference`          | h1 - h2                                                         |
+| `relative_difference` | (h1 - h2) / h2                                                  |
+| `asymmetry`           | (h1 - h2) / (h1 + h2)                                           |
+| `efficiency`          | h1 / h2 (with proper uncertainty propagation from arXiv:physics/0701199) |
+
+## mh.comp.hists() -- Two-Histogram Comparison
+
+Compare two histograms and produce a main plot with a comparison panel below:
+
+```python
+fig, ax_main, ax_comp = mh.comp.hists(
+    h1,
+    h2,
+    comparison="ratio",       # any comparison type from the table above
+    xlabel="Observable [GeV]",
+    ylabel="Events",
+    h1_label="Data",
+    h2_label="MC",
+)
+mh.atlas.label("Internal", data=True, ax=ax_main)
+mh.mpl_magic(soft_fail=True)
+```
+
+Returns a tuple of `(fig, ax_main, ax_comp)`.
+
+## mh.comp.data_model() -- Data vs Model
+
+Compare data to a model consisting of stacked and/or unstacked components:
+
+### Stacked Histogram Components
+
+```python
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2, h_signal],
+    stacked_labels=["Bkg 1", "Bkg 2", "Signal"],
+    xlabel=r"$m_{jj}$ [GeV]",
+    ylabel="Events",
+)
+mh.atlas.label("Internal", data=True, lumi=150, ax=ax_main)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Mixed Stacked and Unstacked
+
+```python
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2],
+    stacked_labels=["Bkg 1", "Bkg 2"],
+    stacked_colors=["grey", "lightblue"],
+    unstacked_components=[h_signal],
+    unstacked_labels=["Signal"],
+    unstacked_colors=["red"],
+    xlabel="Observable [GeV]",
+    ylabel="Events",
+)
+mh.atlas.label("Internal", data=True, lumi=150, ax=ax_main)
+mh.mpl_magic(soft_fail=True)
+```
+
+### Function Components
+
+Components can be callable functions instead of histograms:
+
+```python
+import scipy.stats
+
+def f_signal(x):
+    return 200 * scipy.stats.norm.pdf(x, loc=0.5, scale=3)
+
+def f_bkg(x):
+    return 500 * scipy.stats.norm.pdf(x, loc=-1.5, scale=4)
+
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[f_bkg, f_signal],
+    stacked_labels=["Background", "Signal"],
+    xlabel="Observable [GeV]",
+    ylabel="Events",
+)
+```
+
+### Customizing the Comparison
+
+```python
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2, h_signal],
+    stacked_labels=["Bkg 1", "Bkg 2", "Signal"],
+    comparison="pull",          # default is "split_ratio"
+    model_uncertainty=False,    # remove MC uncertainty band
+    xlabel="Observable [GeV]",
+    ylabel="Events",
+)
+```
+
+### Showing Only One Panel
+
+```python
+# Main plot only (no comparison panel)
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2],
+    stacked_labels=["Bkg 1", "Bkg 2"],
+    plot_only="ax_main",
+    xlabel="Observable [GeV]",
+    ylabel="Events",
+)
+
+# Comparison panel only
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2],
+    stacked_labels=["Bkg 1", "Bkg 2"],
+    plot_only="ax_comparison",
+    xlabel="Observable [GeV]",
+    ylabel="Events",
+)
+```
+
+### Model Sum Line
+
+```python
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2],
+    stacked_labels=["Bkg 1", "Bkg 2"],
+    model_sum_kwargs={"show": True, "label": "Total Model", "color": "violet"},
+    xlabel="Observable [GeV]",
+    ylabel="Events",
+)
+```
+
+## mh.comp.comparison() -- Standalone Comparison Panel
+
+Plot only the comparison panel without a main plot:
+
+```python
+fig, ax = plt.subplots()
+mh.comp.comparison(
+    h1,
+    h2,
+    comparison="ratio",
+    xlabel="Observable [GeV]",
+    h1_label="Data",
+    h2_label="MC",
+    ax=ax,
+)
+```
+
+## mh.comp.get_comparison() -- Numerical Values
+
+Get comparison values without plotting:
+
+```python
+values, lower_unc, upper_unc = mh.comp.get_comparison(
+    h1, h2, comparison="ratio"
+)
+```
+
+## Blinding in Comparisons
+
+The `blind` parameter hides regions in both the main plot and the comparison
+panel.
+
+### Blinding Syntax
+
+| Format                        | Description                         |
+| ----------------------------- | ----------------------------------- |
+| `(-1.0, 1.0)`                | Value-based tuple                   |
+| `"-1j:1j"`                   | String with j suffix for values     |
+| `loc[-1.0:1.0]`              | loc slice notation                  |
+| `19`                          | Single bin index                    |
+| `"15:25"`                     | Range of bin indices                |
+| `[18, 19, 20, 21, 22]`       | List of specific bin indices        |
+| `[(-2.5, -1.5), (1.5, 2.5)]` | Multiple value-based regions        |
+| `"5:1j"`                      | Mixed: index start, value end       |
+
+### Blinding in comp.hists()
+
+```python
+fig, ax_main, ax_comp = mh.comp.hists(
+    h1, h2,
+    blind=(-1.0, 1.0),
+    comparison="ratio",
+    xlabel="Observable [GeV]",
+    ylabel="Events",
+    h1_label="Data",
+    h2_label="MC",
+)
+```
+
+### Blinding in comp.data_model()
+
+```python
+fig, ax_main, ax_comp = mh.comp.data_model(
+    data_hist=h_data,
+    stacked_components=[h_bkg1, h_bkg2],
+    stacked_labels=["Bkg 1", "Bkg 2"],
+    blind=(120, 130),
+    xlabel=r"$m_{H}$ [GeV]",
+    ylabel="Events",
+)
+```
+
+## Custom Multi-Panel Layouts
+
+### Using mh.subplots()
+
+`mh.subplots()` creates multi-row figures with automatic sizing and spacing:
+
+```python
+fig, axes = mh.subplots(nrows=3)
+# axes[0]: main plot
+# axes[1], axes[2]: comparison panels
+```
+
+### Manual Multi-Panel Example
+
+```python
+fig, axes = mh.subplots(nrows=3)
+
+# Main plot
+mh.histplot(h_train_bkg, ax=axes[0], histtype="step", label="Bkg (train)")
+mh.histplot(h_train_sig, ax=axes[0], histtype="step", label="Sig (train)")
+mh.histplot(h_test_bkg, ax=axes[0], histtype="errorbar", label="Bkg (test)")
+mh.histplot(h_test_sig, ax=axes[0], histtype="errorbar", label="Sig (test)")
+axes[0].legend()
+
+# Ratio panel for background
+mh.comp.comparison(
+    h_train_bkg, h_test_bkg,
+    ax=axes[1],
+    comparison="ratio",
+    h1_label="Train",
+    h2_label="Test",
+)
+axes[1].set_ylabel("Ratio")
+
+# Pull panel for signal
+mh.comp.comparison(
+    h_train_sig, h_test_sig,
+    ax=axes[2],
+    comparison="pull",
+    h1_label="Train",
+    h2_label="Test",
+)
+axes[2].set_ylabel("Pull")
+axes[-1].set_xlabel("BDT Score")
+
+fig.align_ylabels()
+mh.atlas.label("Simulation", data=False, ax=axes[0])
+mh.mpl_magic(soft_fail=True)
+```
+
+## Histogram Types for histplot
+
+| histtype    | Description                                              |
+| ----------- | -------------------------------------------------------- |
+| `"step"`    | Step line histogram (default)                            |
+| `"fill"`    | Filled histogram                                         |
+| `"errorbar"`| Data points with error bars                              |
+| `"band"`    | Uncertainty band (useful for visualizing errors)         |
+| `"bar"`     | Side-by-side bars when multiple histograms are given     |
+| `"barstep"` | Side-by-side step bars for multiple histograms           |
+
+## Normalization Options
+
+| Parameter   | Effect                                  |
+| ----------- | --------------------------------------- |
+| (default)   | Raw event counts                        |
+| `density=True` | Normalized so integral equals 1      |
+| `binwnorm=True`| Divided by bin width (Events / unit) |
+
+## Error Bar Control
+
+| Parameter                       | Effect                                      |
+| ------------------------------- | ------------------------------------------- |
+| `yerr=True`                     | Automatic errors (Poisson or from variance) |
+| `yerr=custom_array`             | Explicit error values                       |
+| `w2method="sqrt"`               | sqrt of sum of weights squared              |
+| `w2method="poisson"`            | Poisson interval                            |
+| `w2method=callable`             | Custom function `f(weights, variances)`     |
+
+## Stacking and Sorting
+
+```python
+mh.histplot(
+    [h1, h2, h3],
+    stack=True,           # stack histograms
+    sort="yield",         # sort by total yield (also: "label", "l_r")
+    label=["A", "B", "C"],
+    ax=ax,
+)
+```

--- a/plugins/atlas/skills/panda/SKILL.md
+++ b/plugins/atlas/skills/panda/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: panda
+description: >-
+  Use when submitting ATLAS grid jobs with prun or pathena, monitoring tasks
+  with pbook or BigPanDA, troubleshooting failed grid jobs, choosing between
+  prun and pathena for distributed analysis, or configuring container-based or
+  GPU grid submissions.
+---
+
+# PanDA (Production and Distributed Analysis)
+
+## Overview
+
+PanDA is the ATLAS workload management system for running analysis jobs on the
+grid. Users interact with PanDA through three command-line tools: `prun` (run
+arbitrary executables), `pathena` (run Athena/AnalysisBase jobs), and `pbook`
+(monitor and manage submitted tasks). All three require a valid VOMS proxy and
+the `panda` lsetup package.
+
+## When to Use
+
+- Submitting analysis code to the ATLAS grid for large-scale processing
+- Running custom executables, scripts, or compiled binaries on grid workers
+- Running Athena job options or transformations over grid datasets
+- Monitoring, retrying, or killing submitted tasks
+- Choosing between prun (generic) and pathena (Athena-specific) for a workflow
+- Running containers or GPU-enabled jobs on grid sites
+
+## Key Concepts
+
+| Concept          | Notes                                                                |
+| ---------------- | -------------------------------------------------------------------- |
+| `prun`           | Submit arbitrary executables (C++, Python, shell) to the grid        |
+| `pathena`        | Submit Athena job options or transformations to the grid              |
+| `pbook`          | Bookkeeping: list, monitor, retry, kill tasks                        |
+| `--outDS`        | Output dataset name; must match `user.<account>.<tag>` naming        |
+| `--inDS`         | Input dataset (Rucio name); PanDA splits into per-job file groups    |
+| `--containerImage` | Run inside a Docker or CVMFS container on the worker node          |
+| `--noBuild`      | Skip build step; use pre-built code or a container image             |
+| BigPanDA         | Web interface at https://bigpanda.cern.ch for monitoring tasks       |
+| Build job        | Compiles user code on the grid before running analysis jobs          |
+| VOMS proxy       | Required authentication; `voms-proxy-init --voms atlas`              |
+
+## Canonical Patterns
+
+### Setup
+
+```bash
+setupATLAS
+lsetup panda
+voms-proxy-init --voms atlas
+```
+
+### prun: submit a simple job
+
+```bash
+prun --exec "echo Hello > myout.txt" \
+     --outDS user.$RUCIO_ACCOUNT.hello_test \
+     --nJobs 3 \
+     --output myout.txt
+```
+
+### prun: process input data
+
+Use `%IN` as a placeholder for input file names injected by PanDA.
+
+```bash
+prun --exec "python analysis.py %IN" \
+     --inDS data18_13TeV.DAOD_PHYS.some_dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.analysis_output \
+     --output hist.root \
+     --nFilesPerJob 5
+```
+
+### prun: compiled C++ with build step
+
+`--bexec` runs once before analysis jobs to compile code on the grid.
+
+```bash
+prun --exec "myanalysis %IN" \
+     --bexec "make" \
+     --inDS valid1.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.cpp_test \
+     --output output.root \
+     --rootVer recommended
+```
+
+### prun: container-based job
+
+```bash
+prun --containerImage docker://atlas/analysisbase:25.2.20 \
+     --exec "python analysis.py %IN" \
+     --inDS mc23.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.container_test \
+     --output hist.root \
+     --noBuild
+```
+
+### prun: GPU job
+
+Append `&nvidia` to `--architecture` to request GPU-enabled sites.
+
+```bash
+prun --containerImage docker://myimage:latest \
+     --exec "python train.py" \
+     --outDS user.$RUCIO_ACCOUNT.gpu_training \
+     --nJobs 1 \
+     --noBuild \
+     --architecture '&nvidia'
+```
+
+### pathena: job options
+
+```bash
+asetup AnalysisBase,25.2.20,here
+lsetup panda
+
+pathena MyAnalysisAlg_jobOptions.py \
+     --inDS data18_13TeV.DAOD_PHYSLITE.some_dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.myanalysis_output
+```
+
+### pathena: transformation
+
+Use `--trf` for Athena transform commands. Placeholders: `%IN` (input files),
+`%OUT.suffix` (output with suffix), `%MAXEVENTS`, `%SKIPEVENTS`.
+
+```bash
+pathena --trf "Reco_trf.py inputAODFile=%IN outputNTUP=%OUT.NTUP.root maxEvents=%MAXEVENTS" \
+     --inDS data18_13TeV.AOD.some_dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.reco_output \
+     --nEventsPerJob 10000
+```
+
+### pathena: ComponentAccumulator config
+
+```bash
+pathena --trf "athena.py --CA MyConfig.py --evtMax=%MAXEVENTS --filesInput=%IN" \
+     --inDS mc23.DAOD_PHYSLITE.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.ca_output \
+     --nEventsPerJob 5000
+```
+
+### pathena: test with limited files
+
+Always limit files first to validate the workflow before full-scale submission.
+
+```bash
+pathena jobO.py \
+     --inDS data18.DAOD_PHYSLITE.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.test_run \
+     --nFiles 2
+```
+
+### pbook: monitor and manage tasks
+
+```bash
+# List recent tasks
+pbook show
+
+# Show details for a specific task
+pbook show 12345678
+
+# Long format (includes job-level details)
+pbook showl
+
+# Retry failed jobs in a task
+pbook retry 12345678
+
+# Kill a running task
+pbook kill 12345678
+
+# Finish a task (set remaining undone jobs as failed)
+pbook finish 12345678
+```
+
+### prun: secondary input datasets
+
+Use `--secondaryDSs` to provide additional input datasets accessible via
+`%IN2`, `%IN3`, etc.
+
+```bash
+prun --exec "myanalysis %IN %IN2" \
+     --inDS primary.dataset/ \
+     --secondaryDSs "IN2:3:secondary.dataset/" \
+     --outDS user.$RUCIO_ACCOUNT.multi_input \
+     --output output.root
+```
+
+The format is `NAME:nFilesPerJob:datasetName`. `%IN2` resolves to the files
+from the secondary dataset.
+
+### prun: merge output
+
+```bash
+prun --exec "python analysis.py %IN" \
+     --inDS mc23.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.merged_output \
+     --output hist.root \
+     --nFilesPerJob 10 \
+     --mergeOutput
+```
+
+`%OUT` is available inside `--mergeScript` to reference the merged output
+filename.
+
+## Gotchas
+
+- **VOMS proxy must be valid**: all three tools fail silently or cryptically
+  without a valid proxy. Run `voms-proxy-info` to check expiration.
+- **`--outDS` naming**: must follow `user.<account>.<tag>` format. Reusing an
+  existing dataset name causes submission failure; append a version suffix or
+  timestamp.
+- **Build job failures propagate**: if `--bexec` (prun) or the implicit build
+  step (pathena) fails, all downstream analysis jobs fail with "upstream job
+  failed". Fix the build error and resubmit.
+- **Memory limits on worker nodes**: grid sites typically allow 2–4 GB per core.
+  Reduce `--nFilesPerJob` or `--nGBPerJob` to stay within limits.
+- **`--noBuild` sandbox limit**: pathena's `--noBuild` mode has a 50 MB sandbox
+  limit. For larger payloads, use the default build step or a container.
+- **Container availability**: `--containerImage` pulls from Docker Hub or CVMFS.
+  Ensure the image is publicly accessible or available on CVMFS at the target
+  site.
+- **Placeholder spelling**: `%IN`, `%OUT`, `%RNDM:base` are literal strings
+  inside `--exec`; PanDA substitutes them at runtime. Misspelling causes silent
+  failures.
+- **Multi-core jobs**: use `--nCore N` with pathena to request multi-core queues;
+  without it, multi-threaded code may be killed for over-consuming CPU.
+
+## Interop
+
+- **Rucio**: input and output datasets are managed by Rucio. Use `rucio ls` or
+  the Rucio MCP server to discover dataset names before submission.
+- **setupATLAS / lsetup**: `lsetup panda` provides prun, pathena, and pbook.
+  Combine with `asetup` for Athena-based pathena workflows.
+- **BigPanDA**: https://bigpanda.cern.ch — web monitoring for all PanDA tasks.
+  Filter by username, task ID, or dataset name.
+- **Athena / AnalysisBase**: pathena submits Athena job options or
+  ComponentAccumulator configs. Use `asetup` to configure the release before
+  submission.
+- **ServiceX**: for column-level data extraction without grid jobs, consider
+  ServiceX as a lighter alternative to running prun/pathena for simple
+  selections.
+
+## Worked Example: Grid analysis with prun
+
+Submit a Python analysis script that processes DAOD_PHYSLITE files, produces
+histograms, and merges output.
+
+```bash
+# 1. Setup
+setupATLAS
+lsetup panda
+voms-proxy-init --voms atlas
+
+# 2. Test locally first (always validate before grid submission)
+python analysis.py input_test.root
+
+# 3. Submit to grid with limited files for validation
+prun --exec "python analysis.py %IN" \
+     --inDS mc23_13p6TeV.DAOD_PHYSLITE.ttbar/ \
+     --outDS user.$RUCIO_ACCOUNT.ttbar_hists_v1 \
+     --output hist.root \
+     --nFilesPerJob 5 \
+     --nFiles 10
+
+# 4. Monitor the task
+pbook show
+
+# 5. After validation, submit full dataset
+prun --exec "python analysis.py %IN" \
+     --inDS mc23_13p6TeV.DAOD_PHYSLITE.ttbar/ \
+     --outDS user.$RUCIO_ACCOUNT.ttbar_hists_v2 \
+     --output hist.root \
+     --nFilesPerJob 5 \
+     --mergeOutput
+
+# 6. Retry any failed jobs
+pbook retry <taskID>
+```
+
+## Troubleshooting
+
+| Error                          | Cause                              | Fix                                                     |
+| ------------------------------ | ---------------------------------- | ------------------------------------------------------- |
+| `sh: line 1: XYZ Killed`      | Exceeded memory limit              | Reduce `--nFilesPerJob` or `--nGBPerJob`                |
+| `lost heartbeat`               | No heartbeat for 6 hours           | Usually recovers on `pbook retry`; transient site issue  |
+| `Looping job killed`           | No output update for 2 hours       | Use `--maxCpuCount` for legitimately long jobs           |
+| `upstream job failed`          | Build job (bexec) failed           | Check build log on BigPanDA; fix compilation errors      |
+| `over_cpu_consumption`         | Multi-threaded exceeding CPU share | Use `--nCore N` to request multi-core queue              |
+| Missing output files           | Output stream not used             | Use `--supStream` to suppress unused output streams      |
+| `�proxy expired` / auth errors | VOMS proxy expired                 | Re-run `voms-proxy-init --voms atlas`                    |
+| `�dataset already exists`      | Reused `--outDS` name              | Change dataset name; append version suffix               |
+| Submission hangs               | Network or PanDA server issue      | Check https://bigpanda.cern.ch; retry after a few minutes |
+
+## Docs
+
+https://panda-wms.readthedocs.io/en/latest/
+
+Contact: hn-atlas-dist-analysis-help@cern.ch
+
+Monitor: https://bigpanda.cern.ch

--- a/plugins/atlas/skills/panda/SKILL.md
+++ b/plugins/atlas/skills/panda/SKILL.md
@@ -28,18 +28,18 @@ the `panda` lsetup package.
 
 ## Key Concepts
 
-| Concept          | Notes                                                                |
-| ---------------- | -------------------------------------------------------------------- |
-| `prun`           | Submit arbitrary executables (C++, Python, shell) to the grid        |
-| `pathena`        | Submit Athena job options or transformations to the grid              |
-| `pbook`          | Bookkeeping: list, monitor, retry, kill tasks                        |
-| `--outDS`        | Output dataset name; must match `user.<account>.<tag>` naming        |
-| `--inDS`         | Input dataset (Rucio name); PanDA splits into per-job file groups    |
-| `--containerImage` | Run inside a Docker or CVMFS container on the worker node          |
-| `--noBuild`      | Skip build step; use pre-built code or a container image             |
-| BigPanDA         | Web interface at https://bigpanda.cern.ch for monitoring tasks       |
-| Build job        | Compiles user code on the grid before running analysis jobs          |
-| VOMS proxy       | Required authentication; `voms-proxy-init --voms atlas`              |
+| Concept            | Notes                                                             |
+| ------------------ | ----------------------------------------------------------------- |
+| `prun`             | Submit arbitrary executables (C++, Python, shell) to the grid     |
+| `pathena`          | Submit Athena job options or transformations to the grid          |
+| `pbook`            | Bookkeeping: list, monitor, retry, kill tasks                     |
+| `--outDS`          | Output dataset name; must match `user.<account>.<tag>` naming     |
+| `--inDS`           | Input dataset (Rucio name); PanDA splits into per-job file groups |
+| `--containerImage` | Run inside a Docker or CVMFS container on the worker node         |
+| `--noBuild`        | Skip build step; use pre-built code or a container image          |
+| BigPanDA           | Web interface at https://bigpanda.cern.ch for monitoring tasks    |
+| Build job          | Compiles user code on the grid before running analysis jobs       |
+| VOMS proxy         | Required authentication; `voms-proxy-init --voms atlas`           |
 
 ## Canonical Patterns
 
@@ -176,8 +176,8 @@ pbook finish 12345678
 
 ### prun: secondary input datasets
 
-Use `--secondaryDSs` to provide additional input datasets accessible via
-`%IN2`, `%IN3`, etc.
+Use `--secondaryDSs` to provide additional input datasets accessible via `%IN2`,
+`%IN3`, etc.
 
 ```bash
 prun --exec "myanalysis %IN %IN2" \
@@ -187,8 +187,8 @@ prun --exec "myanalysis %IN %IN2" \
      --output output.root
 ```
 
-The format is `NAME:nFilesPerJob:datasetName`. `%IN2` resolves to the files
-from the secondary dataset.
+The format is `NAME:nFilesPerJob:datasetName`. `%IN2` resolves to the files from
+the secondary dataset.
 
 ### prun: merge output
 
@@ -224,8 +224,8 @@ filename.
 - **Placeholder spelling**: `%IN`, `%OUT`, `%RNDM:base` are literal strings
   inside `--exec`; PanDA substitutes them at runtime. Misspelling causes silent
   failures.
-- **Multi-core jobs**: use `--nCore N` with pathena to request multi-core queues;
-  without it, multi-threaded code may be killed for over-consuming CPU.
+- **Multi-core jobs**: use `--nCore N` with pathena to request multi-core
+  queues; without it, multi-threaded code may be killed for over-consuming CPU.
 
 ## Interop
 
@@ -281,16 +281,16 @@ pbook retry <taskID>
 
 ## Troubleshooting
 
-| Error                          | Cause                              | Fix                                                     |
-| ------------------------------ | ---------------------------------- | ------------------------------------------------------- |
-| `sh: line 1: XYZ Killed`      | Exceeded memory limit              | Reduce `--nFilesPerJob` or `--nGBPerJob`                |
-| `lost heartbeat`               | No heartbeat for 6 hours           | Usually recovers on `pbook retry`; transient site issue  |
-| `Looping job killed`           | No output update for 2 hours       | Use `--maxCpuCount` for legitimately long jobs           |
-| `upstream job failed`          | Build job (bexec) failed           | Check build log on BigPanDA; fix compilation errors      |
-| `over_cpu_consumption`         | Multi-threaded exceeding CPU share | Use `--nCore N` to request multi-core queue              |
-| Missing output files           | Output stream not used             | Use `--supStream` to suppress unused output streams      |
-| `�proxy expired` / auth errors | VOMS proxy expired                 | Re-run `voms-proxy-init --voms atlas`                    |
-| `�dataset already exists`      | Reused `--outDS` name              | Change dataset name; append version suffix               |
+| Error                          | Cause                              | Fix                                                       |
+| ------------------------------ | ---------------------------------- | --------------------------------------------------------- |
+| `sh: line 1: XYZ Killed`       | Exceeded memory limit              | Reduce `--nFilesPerJob` or `--nGBPerJob`                  |
+| `lost heartbeat`               | No heartbeat for 6 hours           | Usually recovers on `pbook retry`; transient site issue   |
+| `Looping job killed`           | No output update for 2 hours       | Use `--maxCpuCount` for legitimately long jobs            |
+| `upstream job failed`          | Build job (bexec) failed           | Check build log on BigPanDA; fix compilation errors       |
+| `over_cpu_consumption`         | Multi-threaded exceeding CPU share | Use `--nCore N` to request multi-core queue               |
+| Missing output files           | Output stream not used             | Use `--supStream` to suppress unused output streams       |
+| `�proxy expired` / auth errors | VOMS proxy expired                 | Re-run `voms-proxy-init --voms atlas`                     |
+| `�dataset already exists`      | Reused `--outDS` name              | Change dataset name; append version suffix                |
 | Submission hangs               | Network or PanDA server issue      | Check https://bigpanda.cern.ch; retry after a few minutes |
 
 ## Docs

--- a/plugins/atlas/skills/panda/SKILL.md
+++ b/plugins/atlas/skills/panda/SKILL.md
@@ -204,6 +204,43 @@ prun --exec "python analysis.py %IN" \
 `%OUT` is available inside `--mergeScript` to reference the merged output
 filename.
 
+## Worked Example: Grid analysis with prun
+
+Submit a Python analysis script that processes DAOD_PHYSLITE files, produces
+histograms, and merges output.
+
+```bash
+# 1. Setup
+setupATLAS
+lsetup panda
+voms-proxy-init --voms atlas
+
+# 2. Test locally first (always validate before grid submission)
+python analysis.py input_test.root
+
+# 3. Submit to grid with limited files for validation
+prun --exec "python analysis.py %IN" \
+     --inDS mc23_13p6TeV.DAOD_PHYSLITE.ttbar/ \
+     --outDS user.$RUCIO_ACCOUNT.ttbar_hists_v1 \
+     --output hist.root \
+     --nFilesPerJob 5 \
+     --nFiles 10
+
+# 4. Monitor the task
+pbook show
+
+# 5. After validation, submit full dataset
+prun --exec "python analysis.py %IN" \
+     --inDS mc23_13p6TeV.DAOD_PHYSLITE.ttbar/ \
+     --outDS user.$RUCIO_ACCOUNT.ttbar_hists_v2 \
+     --output hist.root \
+     --nFilesPerJob 5 \
+     --mergeOutput
+
+# 6. Retry any failed jobs
+pbook retry <taskID>
+```
+
 ## Gotchas
 
 - **VOMS proxy must be valid**: all three tools fail silently or cryptically
@@ -241,43 +278,6 @@ filename.
 - **ServiceX**: for column-level data extraction without grid jobs, consider
   ServiceX as a lighter alternative to running prun/pathena for simple
   selections.
-
-## Worked Example: Grid analysis with prun
-
-Submit a Python analysis script that processes DAOD_PHYSLITE files, produces
-histograms, and merges output.
-
-```bash
-# 1. Setup
-setupATLAS
-lsetup panda
-voms-proxy-init --voms atlas
-
-# 2. Test locally first (always validate before grid submission)
-python analysis.py input_test.root
-
-# 3. Submit to grid with limited files for validation
-prun --exec "python analysis.py %IN" \
-     --inDS mc23_13p6TeV.DAOD_PHYSLITE.ttbar/ \
-     --outDS user.$RUCIO_ACCOUNT.ttbar_hists_v1 \
-     --output hist.root \
-     --nFilesPerJob 5 \
-     --nFiles 10
-
-# 4. Monitor the task
-pbook show
-
-# 5. After validation, submit full dataset
-prun --exec "python analysis.py %IN" \
-     --inDS mc23_13p6TeV.DAOD_PHYSLITE.ttbar/ \
-     --outDS user.$RUCIO_ACCOUNT.ttbar_hists_v2 \
-     --output hist.root \
-     --nFilesPerJob 5 \
-     --mergeOutput
-
-# 6. Retry any failed jobs
-pbook retry <taskID>
-```
 
 ## Troubleshooting
 

--- a/plugins/atlas/skills/panda/SKILL.md
+++ b/plugins/atlas/skills/panda/SKILL.md
@@ -241,6 +241,20 @@ prun --exec "python analysis.py %IN" \
 pbook retry <taskID>
 ```
 
+## Troubleshooting
+
+| Error                         | Cause                              | Fix                                                       |
+| ----------------------------- | ---------------------------------- | --------------------------------------------------------- |
+| `sh: line 1: XYZ Killed`      | Exceeded memory limit              | Reduce `--nFilesPerJob` or `--nGBPerJob`                  |
+| `lost heartbeat`              | No heartbeat for 6 hours           | Usually recovers on `pbook retry`; transient site issue   |
+| `Looping job killed`          | No output update for 2 hours       | Use `--maxCpuCount` for legitimately long jobs            |
+| `upstream job failed`         | Build job (bexec) failed           | Check build log on BigPanDA; fix compilation errors       |
+| `over_cpu_consumption`        | Multi-threaded exceeding CPU share | Use `--nCore N` to request multi-core queue               |
+| Missing output files          | Output stream not used             | Use `--supStream` to suppress unused output streams       |
+| `proxy expired` / auth errors | VOMS proxy expired                 | Re-run `voms-proxy-init --voms atlas`                     |
+| `dataset already exists`      | Reused `--outDS` name              | Change dataset name; append version suffix                |
+| Submission hangs              | Network or PanDA server issue      | Check https://bigpanda.cern.ch; retry after a few minutes |
+
 ## Gotchas
 
 - **VOMS proxy must be valid**: all three tools fail silently or cryptically
@@ -278,20 +292,6 @@ pbook retry <taskID>
 - **ServiceX**: for column-level data extraction without grid jobs, consider
   ServiceX as a lighter alternative to running prun/pathena for simple
   selections.
-
-## Troubleshooting
-
-| Error                          | Cause                              | Fix                                                       |
-| ------------------------------ | ---------------------------------- | --------------------------------------------------------- |
-| `sh: line 1: XYZ Killed`       | Exceeded memory limit              | Reduce `--nFilesPerJob` or `--nGBPerJob`                  |
-| `lost heartbeat`               | No heartbeat for 6 hours           | Usually recovers on `pbook retry`; transient site issue   |
-| `Looping job killed`           | No output update for 2 hours       | Use `--maxCpuCount` for legitimately long jobs            |
-| `upstream job failed`          | Build job (bexec) failed           | Check build log on BigPanDA; fix compilation errors       |
-| `over_cpu_consumption`         | Multi-threaded exceeding CPU share | Use `--nCore N` to request multi-core queue               |
-| Missing output files           | Output stream not used             | Use `--supStream` to suppress unused output streams       |
-| `�proxy expired` / auth errors | VOMS proxy expired                 | Re-run `voms-proxy-init --voms atlas`                     |
-| `�dataset already exists`      | Reused `--outDS` name              | Change dataset name; append version suffix                |
-| Submission hangs               | Network or PanDA server issue      | Check https://bigpanda.cern.ch; retry after a few minutes |
 
 ## Docs
 

--- a/plugins/atlas/skills/panda/references/pathena-options.md
+++ b/plugins/atlas/skills/panda/references/pathena-options.md
@@ -29,81 +29,81 @@ pathena --trf "Transform_trf.py arg1=%IN arg2=%OUT.suffix" --inDS inputDS --outD
 
 ## Input/Output Options
 
-| Option           | Description                                                      |
-| ---------------- | ---------------------------------------------------------------- |
-| `--inDS`         | Input dataset (Rucio name); PanDA splits files across jobs       |
-| `--outDS`        | Output dataset; must match `user.<account>.<tag>`                |
-| `--destSE`       | Destination RSE for output storage                               |
-| `--secondaryDSs` | Secondary input datasets; format: `NAME:nFiles:datasetName/`    |
+| Option           | Description                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| `--inDS`         | Input dataset (Rucio name); PanDA splits files across jobs   |
+| `--outDS`        | Output dataset; must match `user.<account>.<tag>`            |
+| `--destSE`       | Destination RSE for output storage                           |
+| `--secondaryDSs` | Secondary input datasets; format: `NAME:nFiles:datasetName/` |
 
 ## Job Sizing Options
 
-| Option             | Description                                                    |
-| ------------------ | -------------------------------------------------------------- |
-| `--nEventsPerJob`  | Events per job                                                 |
-| `--nFilesPerJob`   | Files per job                                                  |
-| `--nFiles`         | Limit total input files (use for testing before full runs)     |
-| `--nGBPerJob`      | GB per job (alternative to `--nFilesPerJob`)                   |
-| `--split`          | Number of jobs when no input dataset is specified              |
-| `--maxCpuCount`    | Maximum CPU time in seconds                                    |
-| `--maxWalltime`    | Maximum wall clock time in seconds                             |
+| Option            | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `--nEventsPerJob` | Events per job                                             |
+| `--nFilesPerJob`  | Files per job                                              |
+| `--nFiles`        | Limit total input files (use for testing before full runs) |
+| `--nGBPerJob`     | GB per job (alternative to `--nFilesPerJob`)               |
+| `--split`         | Number of jobs when no input dataset is specified          |
+| `--maxCpuCount`   | Maximum CPU time in seconds                                |
+| `--maxWalltime`   | Maximum wall clock time in seconds                         |
 
 ## Build Options
 
-| Option           | Description                                                      |
-| ---------------- | ---------------------------------------------------------------- |
-| `--noBuild`      | Skip build step; 50 MB sandbox limit applies                     |
-| `--noCompile`    | Include source but skip compilation                              |
-| `--extFile`      | Additional files to include in the sandbox                       |
-| `--excludeFile`  | Glob patterns to exclude from the sandbox                        |
+| Option          | Description                                  |
+| --------------- | -------------------------------------------- |
+| `--noBuild`     | Skip build step; 50 MB sandbox limit applies |
+| `--noCompile`   | Include source but skip compilation          |
+| `--extFile`     | Additional files to include in the sandbox   |
+| `--excludeFile` | Glob patterns to exclude from the sandbox    |
 
 ## Site and Resource Options
 
-| Option              | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| `--site`            | Target specific site                                           |
-| `--excludedSite`    | Comma-separated sites to avoid                                 |
-| `--cloud`           | Target cloud (e.g. `US`, `CERN`)                               |
-| `--memory`          | Requested memory in MB                                         |
-| `--nCore`           | Number of CPU cores; routes to multi-core queues               |
-| `--maxDiskCount`    | Maximum disk usage in KB per job                               |
+| Option           | Description                                      |
+| ---------------- | ------------------------------------------------ |
+| `--site`         | Target specific site                             |
+| `--excludedSite` | Comma-separated sites to avoid                   |
+| `--cloud`        | Target cloud (e.g. `US`, `CERN`)                 |
+| `--memory`       | Requested memory in MB                           |
+| `--nCore`        | Number of CPU cores; routes to multi-core queues |
+| `--maxDiskCount` | Maximum disk usage in KB per job                 |
 
 ## Athena-Specific Options
 
-| Option              | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| `--trf`             | Transformation command string (alternative to job options)      |
-| `--CA`              | Enable ComponentAccumulator configuration mode                  |
-| `--athenaTag`       | Override the Athena version tag                                 |
-| `--useAthenaPackages` | Include Athena packages from the work area                   |
+| Option                | Description                                                |
+| --------------------- | ---------------------------------------------------------- |
+| `--trf`               | Transformation command string (alternative to job options) |
+| `--CA`                | Enable ComponentAccumulator configuration mode             |
+| `--athenaTag`         | Override the Athena version tag                            |
+| `--useAthenaPackages` | Include Athena packages from the work area                 |
 
 ## Production Options
 
-| Option              | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| `--official`        | Submit as group production (requires `--voms`)                 |
-| `--voms`            | VOMS role for group production (e.g. `atlas:/atlas/phys-hdbs`) |
+| Option       | Description                                                    |
+| ------------ | -------------------------------------------------------------- |
+| `--official` | Submit as group production (requires `--voms`)                 |
+| `--voms`     | VOMS role for group production (e.g. `atlas:/atlas/phys-hdbs`) |
 
 ## Event Picking
 
-| Option                   | Description                                             |
-| ------------------------ | ------------------------------------------------------- |
-| `--eventPickEvtList`     | Text file with run:event pairs to pick                  |
-| `--eventPickDataType`    | Data type to pick from (e.g. `AOD`, `ESD`)              |
-| `--eventPickStreamName`  | Stream name filter                                      |
+| Option                  | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `--eventPickEvtList`    | Text file with run:event pairs to pick     |
+| `--eventPickDataType`   | Data type to pick from (e.g. `AOD`, `ESD`) |
+| `--eventPickStreamName` | Stream name filter                         |
 
 ## Placeholder Variables
 
 Use inside `--trf` strings. PanDA substitutes at runtime.
 
-| Placeholder      | Resolves to                                                    |
-| ---------------- | -------------------------------------------------------------- |
-| `%IN`            | Comma-separated input file names for this job                  |
-| `%OUT.suffix`    | Output file with given suffix (e.g. `%OUT.NTUP.root`)         |
-| `%MAXEVENTS`     | Maximum events to process in this job                          |
-| `%SKIPEVENTS`    | Number of events to skip (for splitting)                       |
-| `%RNDM:base`     | Random seed derived from `base + jobID`                       |
-| `%CORE_NUMBER`   | Number of allocated cores (use with `--nCore`)                 |
+| Placeholder    | Resolves to                                           |
+| -------------- | ----------------------------------------------------- |
+| `%IN`          | Comma-separated input file names for this job         |
+| `%OUT.suffix`  | Output file with given suffix (e.g. `%OUT.NTUP.root`) |
+| `%MAXEVENTS`   | Maximum events to process in this job                 |
+| `%SKIPEVENTS`  | Number of events to skip (for splitting)              |
+| `%RNDM:base`   | Random seed derived from `base + jobID`               |
+| `%CORE_NUMBER` | Number of allocated cores (use with `--nCore`)        |
 
 ## Examples
 

--- a/plugins/atlas/skills/panda/references/pathena-options.md
+++ b/plugins/atlas/skills/panda/references/pathena-options.md
@@ -1,0 +1,200 @@
+# pathena — Full Option Reference
+
+pathena submits Athena job options or transformation commands to the ATLAS grid
+via PanDA. It automatically packages the user's work area (including compiled
+libraries from `asetup`) and creates a build job on the grid.
+
+## Setup
+
+```bash
+setupATLAS
+asetup AnalysisBase,25.2.20,here   # or any Athena release
+lsetup panda
+voms-proxy-init --voms atlas
+```
+
+## Basic Syntax
+
+### Job options mode
+
+```bash
+pathena jobOptions.py --inDS inputDS --outDS outputDS [options]
+```
+
+### Transformation mode
+
+```bash
+pathena --trf "Transform_trf.py arg1=%IN arg2=%OUT.suffix" --inDS inputDS --outDS outputDS [options]
+```
+
+## Input/Output Options
+
+| Option           | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| `--inDS`         | Input dataset (Rucio name); PanDA splits files across jobs       |
+| `--outDS`        | Output dataset; must match `user.<account>.<tag>`                |
+| `--destSE`       | Destination RSE for output storage                               |
+| `--secondaryDSs` | Secondary input datasets; format: `NAME:nFiles:datasetName/`    |
+
+## Job Sizing Options
+
+| Option             | Description                                                    |
+| ------------------ | -------------------------------------------------------------- |
+| `--nEventsPerJob`  | Events per job                                                 |
+| `--nFilesPerJob`   | Files per job                                                  |
+| `--nFiles`         | Limit total input files (use for testing before full runs)     |
+| `--nGBPerJob`      | GB per job (alternative to `--nFilesPerJob`)                   |
+| `--split`          | Number of jobs when no input dataset is specified              |
+| `--maxCpuCount`    | Maximum CPU time in seconds                                    |
+| `--maxWalltime`    | Maximum wall clock time in seconds                             |
+
+## Build Options
+
+| Option           | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| `--noBuild`      | Skip build step; 50 MB sandbox limit applies                     |
+| `--noCompile`    | Include source but skip compilation                              |
+| `--extFile`      | Additional files to include in the sandbox                       |
+| `--excludeFile`  | Glob patterns to exclude from the sandbox                        |
+
+## Site and Resource Options
+
+| Option              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `--site`            | Target specific site                                           |
+| `--excludedSite`    | Comma-separated sites to avoid                                 |
+| `--cloud`           | Target cloud (e.g. `US`, `CERN`)                               |
+| `--memory`          | Requested memory in MB                                         |
+| `--nCore`           | Number of CPU cores; routes to multi-core queues               |
+| `--maxDiskCount`    | Maximum disk usage in KB per job                               |
+
+## Athena-Specific Options
+
+| Option              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `--trf`             | Transformation command string (alternative to job options)      |
+| `--CA`              | Enable ComponentAccumulator configuration mode                  |
+| `--athenaTag`       | Override the Athena version tag                                 |
+| `--useAthenaPackages` | Include Athena packages from the work area                   |
+
+## Production Options
+
+| Option              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `--official`        | Submit as group production (requires `--voms`)                 |
+| `--voms`            | VOMS role for group production (e.g. `atlas:/atlas/phys-hdbs`) |
+
+## Event Picking
+
+| Option                   | Description                                             |
+| ------------------------ | ------------------------------------------------------- |
+| `--eventPickEvtList`     | Text file with run:event pairs to pick                  |
+| `--eventPickDataType`    | Data type to pick from (e.g. `AOD`, `ESD`)              |
+| `--eventPickStreamName`  | Stream name filter                                      |
+
+## Placeholder Variables
+
+Use inside `--trf` strings. PanDA substitutes at runtime.
+
+| Placeholder      | Resolves to                                                    |
+| ---------------- | -------------------------------------------------------------- |
+| `%IN`            | Comma-separated input file names for this job                  |
+| `%OUT.suffix`    | Output file with given suffix (e.g. `%OUT.NTUP.root`)         |
+| `%MAXEVENTS`     | Maximum events to process in this job                          |
+| `%SKIPEVENTS`    | Number of events to skip (for splitting)                       |
+| `%RNDM:base`     | Random seed derived from `base + jobID`                       |
+| `%CORE_NUMBER`   | Number of allocated cores (use with `--nCore`)                 |
+
+## Examples
+
+### Job options with input data
+
+```bash
+pathena MyAnalysis_jobOptions.py \
+     --inDS data18_13TeV.DAOD_PHYSLITE.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.analysis_v1
+```
+
+### Test with limited files
+
+Always limit files when validating a new workflow.
+
+```bash
+pathena MyAnalysis_jobOptions.py \
+     --inDS data18_13TeV.DAOD_PHYSLITE.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.test_v1 \
+     --nFiles 2
+```
+
+### Transformation with event splitting
+
+```bash
+pathena --trf "Reco_trf.py inputAODFile=%IN outputNTUP=%OUT.NTUP.root maxEvents=%MAXEVENTS" \
+     --inDS data18_13TeV.AOD.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.reco_v1 \
+     --nEventsPerJob 10000
+```
+
+### ComponentAccumulator configuration
+
+```bash
+pathena --trf "athena.py --CA MyConfig.py --evtMax=%MAXEVENTS --filesInput=%IN" \
+     --inDS mc23.DAOD_PHYSLITE.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.ca_output \
+     --nEventsPerJob 5000
+```
+
+### Multi-core job
+
+```bash
+pathena MyAnalysis_jobOptions.py \
+     --inDS mc23.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.multicore_v1 \
+     --nCore 8 \
+     --nEventsPerJob 50000
+```
+
+### Event picking
+
+Select specific events by run and event number from a text file.
+
+```bash
+# events.txt format (one per line):
+# 123456:789
+# 123456:790
+
+pathena MyAnalysis_jobOptions.py \
+     --eventPickEvtList events.txt \
+     --eventPickDataType AOD \
+     --outDS user.$RUCIO_ACCOUNT.picked_events
+```
+
+### Group production
+
+```bash
+pathena MyAnalysis_jobOptions.py \
+     --inDS mc23.dataset/ \
+     --outDS group.phys-hdbs.production_v1 \
+     --official \
+     --voms atlas:/atlas/phys-hdbs
+```
+
+### noBuild mode (small payload)
+
+Skip compilation when the payload fits in the 50 MB sandbox limit.
+
+```bash
+pathena MyScript.py \
+     --inDS mc23.DAOD_PHYSLITE.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.nobuild_test \
+     --noBuild
+```
+
+### Output to specific storage element
+
+```bash
+pathena MyAnalysis_jobOptions.py \
+     --inDS mc23.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.analysis_v1 \
+     --destSE BNL-OSG2_LOCALGROUPDISK
+```

--- a/plugins/atlas/skills/panda/references/prun-options.md
+++ b/plugins/atlas/skills/panda/references/prun-options.md
@@ -20,78 +20,78 @@ prun --exec "command" --outDS user.<account>.<tag> [options]
 
 ## Execution Options
 
-| Option             | Description                                                        |
-| ------------------ | ------------------------------------------------------------------ |
+| Option             | Description                                                         |
+| ------------------ | ------------------------------------------------------------------- |
 | `--exec "cmd"`     | Execution string; supports `%IN`, `%OUT`, `%RNDM:base` placeholders |
-| `--bexec "cmd"`    | Build step command (runs once before analysis jobs, e.g. `make`)   |
-| `--noBuild`        | Skip build step; use for containers or pre-built code              |
-| `--containerImage` | Docker image (`docker://...`) or CVMFS image for the worker node   |
-| `--architecture`   | CPU/GPU spec; append `&nvidia` for GPU (e.g. `'&nvidia'`)         |
+| `--bexec "cmd"`    | Build step command (runs once before analysis jobs, e.g. `make`)    |
+| `--noBuild`        | Skip build step; use for containers or pre-built code               |
+| `--containerImage` | Docker image (`docker://...`) or CVMFS image for the worker node    |
+| `--architecture`   | CPU/GPU spec; append `&nvidia` for GPU (e.g. `'&nvidia'`)           |
 
 ## Input/Output Options
 
-| Option             | Description                                                     |
-| ------------------ | --------------------------------------------------------------- |
-| `--inDS`           | Input dataset (Rucio name); PanDA splits across jobs            |
-| `--outDS`          | Output dataset; must match `user.<account>.<tag>`               |
-| `--output`         | Comma-separated output file names to collect from the worker    |
-| `--secondaryDSs`   | Secondary input datasets; format: `NAME:nFiles:datasetName/`    |
-| `--mergeOutput`    | Merge output files after all jobs complete                      |
-| `--mergeScript`    | Custom merge script; `%OUT` placeholder for merged file name    |
-| `--destSE`         | Destination RSE for output (default: closest to submission site) |
+| Option           | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| `--inDS`         | Input dataset (Rucio name); PanDA splits across jobs             |
+| `--outDS`        | Output dataset; must match `user.<account>.<tag>`                |
+| `--output`       | Comma-separated output file names to collect from the worker     |
+| `--secondaryDSs` | Secondary input datasets; format: `NAME:nFiles:datasetName/`     |
+| `--mergeOutput`  | Merge output files after all jobs complete                       |
+| `--mergeScript`  | Custom merge script; `%OUT` placeholder for merged file name     |
+| `--destSE`       | Destination RSE for output (default: closest to submission site) |
 
 ## Job Sizing Options
 
-| Option             | Description                                                     |
-| ------------------ | --------------------------------------------------------------- |
-| `--nJobs`          | Number of jobs (when no `--inDS`)                               |
-| `--nFilesPerJob`   | Files per job (with `--inDS`)                                   |
-| `--nGBPerJob`      | GB per job (alternative to `--nFilesPerJob`)                    |
-| `--nEventsPerJob`  | Events per job                                                  |
-| `--nFiles`         | Limit total input files (use for testing)                       |
-| `--maxCpuCount`    | Maximum CPU time in seconds; increase for long jobs             |
-| `--maxWalltime`    | Maximum wall clock time in seconds                              |
+| Option            | Description                                         |
+| ----------------- | --------------------------------------------------- |
+| `--nJobs`         | Number of jobs (when no `--inDS`)                   |
+| `--nFilesPerJob`  | Files per job (with `--inDS`)                       |
+| `--nGBPerJob`     | GB per job (alternative to `--nFilesPerJob`)        |
+| `--nEventsPerJob` | Events per job                                      |
+| `--nFiles`        | Limit total input files (use for testing)           |
+| `--maxCpuCount`   | Maximum CPU time in seconds; increase for long jobs |
+| `--maxWalltime`   | Maximum wall clock time in seconds                  |
 
 ## Site and Resource Options
 
-| Option              | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| `--site`            | Target specific site (e.g. `CERN-PROD`)                        |
-| `--excludedSite`    | Comma-separated sites to avoid                                 |
-| `--cloud`           | Target cloud (e.g. `US`, `CERN`)                               |
-| `--memory`          | Requested memory in MB                                         |
-| `--nCore`           | Number of CPU cores per job                                    |
-| `--maxDiskCount`    | Maximum disk usage in KB per job                               |
+| Option           | Description                             |
+| ---------------- | --------------------------------------- |
+| `--site`         | Target specific site (e.g. `CERN-PROD`) |
+| `--excludedSite` | Comma-separated sites to avoid          |
+| `--cloud`        | Target cloud (e.g. `US`, `CERN`)        |
+| `--memory`       | Requested memory in MB                  |
+| `--nCore`        | Number of CPU cores per job             |
+| `--maxDiskCount` | Maximum disk usage in KB per job        |
 
 ## ROOT and Software Options
 
-| Option              | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| `--rootVer`         | ROOT version; use `recommended` for latest stable              |
-| `--cmtConfig`       | CMT configuration tag                                          |
-| `--useAthenaPackages` | Include Athena packages in the sandbox                       |
+| Option                | Description                                       |
+| --------------------- | ------------------------------------------------- |
+| `--rootVer`           | ROOT version; use `recommended` for latest stable |
+| `--cmtConfig`         | CMT configuration tag                             |
+| `--useAthenaPackages` | Include Athena packages in the sandbox            |
 
 ## Sandbox Options
 
-| Option              | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| `--extFile`         | Additional files to include in the sandbox                     |
-| `--excludeFile`     | Glob patterns of files to exclude from the sandbox             |
-| `--noCompile`       | Do not compile even if `--bexec` is set                        |
+| Option          | Description                                        |
+| --------------- | -------------------------------------------------- |
+| `--extFile`     | Additional files to include in the sandbox         |
+| `--excludeFile` | Glob patterns of files to exclude from the sandbox |
+| `--noCompile`   | Do not compile even if `--bexec` is set            |
 
 ## Placeholder Variables
 
 Use these inside `--exec` strings. PanDA substitutes them at runtime on the
 worker node.
 
-| Placeholder     | Resolves to                                                   |
-| --------------- | ------------------------------------------------------------- |
-| `%IN`           | Comma-separated list of input file names for this job         |
-| `%IN2`, `%IN3`  | Files from secondary datasets (see `--secondaryDSs`)          |
-| `%OUT`          | Output file name in merge step (use with `--mergeScript`)     |
-| `%RNDM:base`    | Random seed derived from `base + jobID`; reproducible per job |
-| `%SKIPEVENTS`   | Number of events to skip (for event-level splitting)          |
-| `%MAXEVENTS`    | Maximum events for this job                                   |
+| Placeholder    | Resolves to                                                   |
+| -------------- | ------------------------------------------------------------- |
+| `%IN`          | Comma-separated list of input file names for this job         |
+| `%IN2`, `%IN3` | Files from secondary datasets (see `--secondaryDSs`)          |
+| `%OUT`         | Output file name in merge step (use with `--mergeScript`)     |
+| `%RNDM:base`   | Random seed derived from `base + jobID`; reproducible per job |
+| `%SKIPEVENTS`  | Number of events to skip (for event-level splitting)          |
+| `%MAXEVENTS`   | Maximum events for this job                                   |
 
 ## Examples
 

--- a/plugins/atlas/skills/panda/references/prun-options.md
+++ b/plugins/atlas/skills/panda/references/prun-options.md
@@ -1,0 +1,189 @@
+# prun — Full Option Reference
+
+prun submits arbitrary executables to the ATLAS grid via PanDA. It packages the
+current working directory as a sandbox, optionally runs a build step, then
+distributes analysis jobs across grid sites.
+
+## Setup
+
+```bash
+setupATLAS
+lsetup panda
+voms-proxy-init --voms atlas
+```
+
+## Basic Syntax
+
+```bash
+prun --exec "command" --outDS user.<account>.<tag> [options]
+```
+
+## Execution Options
+
+| Option             | Description                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| `--exec "cmd"`     | Execution string; supports `%IN`, `%OUT`, `%RNDM:base` placeholders |
+| `--bexec "cmd"`    | Build step command (runs once before analysis jobs, e.g. `make`)   |
+| `--noBuild`        | Skip build step; use for containers or pre-built code              |
+| `--containerImage` | Docker image (`docker://...`) or CVMFS image for the worker node   |
+| `--architecture`   | CPU/GPU spec; append `&nvidia` for GPU (e.g. `'&nvidia'`)         |
+
+## Input/Output Options
+
+| Option             | Description                                                     |
+| ------------------ | --------------------------------------------------------------- |
+| `--inDS`           | Input dataset (Rucio name); PanDA splits across jobs            |
+| `--outDS`          | Output dataset; must match `user.<account>.<tag>`               |
+| `--output`         | Comma-separated output file names to collect from the worker    |
+| `--secondaryDSs`   | Secondary input datasets; format: `NAME:nFiles:datasetName/`    |
+| `--mergeOutput`    | Merge output files after all jobs complete                      |
+| `--mergeScript`    | Custom merge script; `%OUT` placeholder for merged file name    |
+| `--destSE`         | Destination RSE for output (default: closest to submission site) |
+
+## Job Sizing Options
+
+| Option             | Description                                                     |
+| ------------------ | --------------------------------------------------------------- |
+| `--nJobs`          | Number of jobs (when no `--inDS`)                               |
+| `--nFilesPerJob`   | Files per job (with `--inDS`)                                   |
+| `--nGBPerJob`      | GB per job (alternative to `--nFilesPerJob`)                    |
+| `--nEventsPerJob`  | Events per job                                                  |
+| `--nFiles`         | Limit total input files (use for testing)                       |
+| `--maxCpuCount`    | Maximum CPU time in seconds; increase for long jobs             |
+| `--maxWalltime`    | Maximum wall clock time in seconds                              |
+
+## Site and Resource Options
+
+| Option              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `--site`            | Target specific site (e.g. `CERN-PROD`)                        |
+| `--excludedSite`    | Comma-separated sites to avoid                                 |
+| `--cloud`           | Target cloud (e.g. `US`, `CERN`)                               |
+| `--memory`          | Requested memory in MB                                         |
+| `--nCore`           | Number of CPU cores per job                                    |
+| `--maxDiskCount`    | Maximum disk usage in KB per job                               |
+
+## ROOT and Software Options
+
+| Option              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `--rootVer`         | ROOT version; use `recommended` for latest stable              |
+| `--cmtConfig`       | CMT configuration tag                                          |
+| `--useAthenaPackages` | Include Athena packages in the sandbox                       |
+
+## Sandbox Options
+
+| Option              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `--extFile`         | Additional files to include in the sandbox                     |
+| `--excludeFile`     | Glob patterns of files to exclude from the sandbox             |
+| `--noCompile`       | Do not compile even if `--bexec` is set                        |
+
+## Placeholder Variables
+
+Use these inside `--exec` strings. PanDA substitutes them at runtime on the
+worker node.
+
+| Placeholder     | Resolves to                                                   |
+| --------------- | ------------------------------------------------------------- |
+| `%IN`           | Comma-separated list of input file names for this job         |
+| `%IN2`, `%IN3`  | Files from secondary datasets (see `--secondaryDSs`)          |
+| `%OUT`          | Output file name in merge step (use with `--mergeScript`)     |
+| `%RNDM:base`    | Random seed derived from `base + jobID`; reproducible per job |
+| `%SKIPEVENTS`   | Number of events to skip (for event-level splitting)          |
+| `%MAXEVENTS`    | Maximum events for this job                                   |
+
+## Examples
+
+### Hello world (no input)
+
+```bash
+prun --exec "echo Hello > myout.txt" \
+     --outDS user.$RUCIO_ACCOUNT.hello_test \
+     --nJobs 3 \
+     --output myout.txt
+```
+
+### Python script with input data
+
+```bash
+prun --exec "python analysis.py %IN" \
+     --inDS data18_13TeV.DAOD_PHYSLITE.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.analysis_v1 \
+     --output hist.root \
+     --nFilesPerJob 5
+```
+
+### C++ with build step
+
+```bash
+prun --exec "myanalysis %IN" \
+     --bexec "make" \
+     --inDS valid1.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.cpp_analysis \
+     --output output.root \
+     --rootVer recommended
+```
+
+### Docker container
+
+```bash
+prun --containerImage docker://atlas/analysisbase:25.2.20 \
+     --exec "python analysis.py %IN" \
+     --inDS mc23.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.container_run \
+     --output hist.root \
+     --noBuild
+```
+
+### GPU job
+
+```bash
+prun --containerImage docker://myimage:gpu \
+     --exec "python train.py" \
+     --outDS user.$RUCIO_ACCOUNT.gpu_training \
+     --nJobs 1 \
+     --noBuild \
+     --architecture '&nvidia'
+```
+
+### Secondary datasets
+
+```bash
+prun --exec "myanalysis %IN %IN2" \
+     --inDS primary.dataset/ \
+     --secondaryDSs "IN2:3:secondary.dataset/" \
+     --outDS user.$RUCIO_ACCOUNT.multi_input \
+     --output output.root
+```
+
+### Random seeds for MC generation
+
+```bash
+prun --exec "generate.py --seed %RNDM:12345" \
+     --outDS user.$RUCIO_ACCOUNT.mc_gen \
+     --nJobs 100 \
+     --output events.root
+```
+
+### Merge output
+
+```bash
+prun --exec "python analysis.py %IN" \
+     --inDS mc23.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.merged \
+     --output hist.root \
+     --nFilesPerJob 10 \
+     --mergeOutput
+```
+
+### Site selection
+
+```bash
+prun --exec "python analysis.py %IN" \
+     --inDS mc23.dataset/ \
+     --outDS user.$RUCIO_ACCOUNT.site_test \
+     --output hist.root \
+     --site CERN-PROD \
+     --excludedSite BNL-OSG2
+```

--- a/plugins/atlas/skills/pyhf/SKILL.md
+++ b/plugins/atlas/skills/pyhf/SKILL.md
@@ -225,6 +225,21 @@ print(f"Observed limit: μ < {obs_limit:.2f} @ 95% CL")
 | Expected limit varies wildly           | Too few Asimov toy statistics            | Check background yields — should be > 10 events/bin      |
 | NP pulled strongly                     | Template inconsistent with data          | Inspect pre-fit data/MC in that region                   |
 
+## Gotchas
+
+- **Channel and sample names must be unique**: duplicate names within a
+  workspace raise `InvalidSpecification` at construction time.
+- **Shared modifier names**: a modifier with the same name and type in multiple
+  channels/samples is treated as a single correlated NP — intentional for
+  luminosity, but accidental sharing causes unexpected correlations.
+- **JAX float32 default**: JAX uses 32-bit floats by default; add
+  `jax.config.update("jax_enable_x64", True)` before importing pyhf to avoid
+  precision loss in fits.
+- **Empty bins**: a bin with zero expected yield produces `nan` in the
+  log-likelihood. Add a small regularisation value or merge bins.
+- **Integer yields are float internally**: pyhf casts all data to the backend
+  float type; ensure histograms are passed as floats to avoid silent truncation.
+
 ## Interop
 
 - **cabinetry**: high-level wrapper that builds pyhf workspaces from config +

--- a/plugins/atlas/skills/quickfit/SKILL.md
+++ b/plugins/atlas/skills/quickfit/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: quickfit
+description: >-
+  Use when fitting a RooWorkspace dataset with quickFit, generating an Asimov
+  dataset with quickAsimov, computing asymptotic CLs limits with quickLimit,
+  generating toy datasets with quickToy, rebinning datasets with quickRebin, or
+  calculating nuisance parameter pulls with quickPull.
+---
+
+# quickFit
+
+## Overview
+
+quickFit is a suite of command-line tools for statistical operations on a
+RooWorkspace. It provides rapid fitting, Asimov generation, CLs limit
+computation, toy generation, dataset rebinning, and NP pull calculations. All
+tools share a common interface and depend on ROOT and
+[RooFitExtensions](https://gitlab.cern.ch/atlas_higgs_combination/software/RooFitExtensions).
+
+quickFit is included in the StatAnalysis release (all executables available
+after `asetup StatAnalysis,0.7,latest`). It can also be built standalone.
+
+Repository: https://gitlab.cern.ch/atlas_higgs_combination/software/quickFit
+
+## Standalone Installation
+
+```bash
+git clone ssh://git@gitlab.cern.ch:7999/atlas_higgs_combination/software/quickFit.git
+cd quickFit
+source setup_lxplus.sh   # sets up ROOT, cmake, boost from CVMFS
+sh scripts/install_roofitext.sh   # install RooFitExtensions if not present
+mkdir build && cd build
+cmake ..
+make && make install
+cd ..
+```
+
+After the build, re-run `source setup_lxplus.sh` before using executables.
+
+## quickFit — Fitting a Workspace
+
+```bash
+# Basic fit with floating POIs
+quickFit -f ws.root -d dataset -p mu=1_-5_5
+
+# Float mu_ggH, fix mu_VBF=2
+quickFit -f ws.root -d dataset -p mu_ggH=1_-5_5,mu_VBF=2
+
+# Fix all NPs matching ATLAS_* prefix
+quickFit -f ws.root -d dataset -p mu=1_-5_5 -n "ATLAS_*"
+
+# Run HESSE and MINOS on top of MIGRAD
+quickFit -f ws.root -d dataset -p mu=1_-5_5 --hesse 1 --minos 1
+
+# Save fit results to file
+quickFit -f ws.root -d dataset -p mu=1_-5_5 -o output.root --savefitresult 1
+
+# Parallel evaluation (multi-core or GPU)
+quickFit --useModularL=true --numCPU=4 -f ws.root -d dataset -p mu=1_-5_5
+quickFit --EvalBackend=cuda -f ws.root -d dataset -p mu=1_-5_5
+```
+
+### Parameter syntax (`-p`)
+
+| Form | Meaning |
+|---|---|
+| `mu=1_-5_5` | Float `mu` with initial value 1, range [−5, 5] |
+| `mu=2` | Fix `mu` at 2 |
+| `mu_ggH=1_-5_5,mu_VBF=1_-5_5` | Multiple params, comma-separated |
+
+### Key quickFit options
+
+| Option | Description |
+|---|---|
+| `-f` | Input workspace ROOT file |
+| `-w` | Workspace name (default: `combWS`) |
+| `-m` | ModelConfig name (default: `ModelConfig`) |
+| `-d` | Dataset name to fit |
+| `-p` | POI/parameter configuration |
+| `-n` | Fix NPs matching pattern |
+| `-o` | Output ROOT file |
+| `--savefitresult` | 0 = NLL only, 1 = full RooFitResult |
+| `--hesse` | Run HESSE after MIGRAD (1=yes) |
+| `--minos` | Run MINOS (1=yes) |
+| `--useModularL` | Enable modular likelihood evaluation |
+| `--numCPU` | Number of cores for parallel evaluation |
+| `--EvalBackend` | Evaluation backend (`cpu`, `cuda`, etc.) |
+| `--minTolerance` | Minimizer tolerance |
+
+## quickAsimov — Generating Asimov Datasets
+
+`quickAsimov` reads an XML card describing fit and Asimov generation actions.
+
+```bash
+quickAsimov -x card.xml -w combWS -m ModelConfig -d obsData
+```
+
+### XML card format
+
+```xml
+<!DOCTYPE Asimov SYSTEM 'asimovUtil.dtd'>
+<Asimov InputFile="input.root" OutputFile="output.root" POI="mu">
+  <Action Name="Prepare" Setup="" Action="nominalNuis:nominalGlobs"/>
+  <Action Name="Fit" Setup="mu=1_0_5"
+          Action="fit:matchglob:savesnapshot"
+          SnapshotNuis="conditionalNuis_1"
+          SnapshotGlob="conditionalGlob_1"/>
+  <Action Name="asimovData_1" Setup="mu=1"
+          Action="genasimov:nominalGlobs"/>
+</Asimov>
+```
+
+### Action keywords (colon-separated in `Action` attribute)
+
+| Keyword | Meaning |
+|---|---|
+| `fit` | Perform maximum likelihood fit |
+| `genasimov` | Generate Asimov dataset (once per action list) |
+| `savesnapshot` | Save parameter snapshot (once per action list) |
+| `matchglob` | Match global observables to NP values (use with `reset`) |
+| `reset` | Reset parameters to state before current action list |
+| `raw` | Reset to state before any actions |
+| `fixsyst` | Fix all constrained NPs |
+| `float` | Float NPs fixed by `fixsyst` or `Setup` |
+| `<snapshot name>` | Load a saved snapshot |
+
+## quickLimit — Asymptotic CLs Limits
+
+```bash
+quickLimit -f ws.root -w combWS -m ModelConfig -d obsData -p mu -o limits.root
+```
+
+- Output: ROOT file with limit histograms + `.txt` file with numeric results.
+- Only one POI is processed for limit setting; use the first listed with `-p`.
+- Other POIs can still be configured via `-p` for fixing/floating.
+
+## quickToy — Generating Toy Datasets
+
+Requires snapshots already saved in the workspace (e.g. from `quickAsimov`).
+
+```bash
+quickToy -f ws.root -d toyData \
+  -p mu=1,mu_ggH=1 \
+  -s conditionalGlob_1,conditionalNuis_1 \
+  -o output.root --seed 1
+```
+
+Use a different `--seed` for each independent toy.
+
+## quickRebin — Rebinning a Dataset
+
+Converts an unbinned dataset to a pseudo-binned one for faster fitting:
+
+```bash
+quickRebin -f output.root -d toyData -o output_binned.root -r 500
+```
+
+Creates `toyDatabinned` in the output file with 500 bins. Categories where
+the number of entries is less than the bin count remain unbinned.
+
+## quickPull — NP Pull to a POI
+
+```bash
+quickPull -f ws.root -w combWS -d combData \
+  -p mu=1_0_5,mu_VBF=1 \
+  --nui_param ATLAS_EG_RESOLUTION_ALL \
+  --pull_POI mu \
+  -o ATLAS_EG_RESOLUTION_ALL.root
+```
+
+## Gotchas
+
+- **Custom classes**: If the workspace uses custom RooFit classes (from
+  `RooFitExtensions` or local code), ensure `LD_LIBRARY_PATH` includes the
+  library directory before opening the workspace, or the program will crash.
+- **`matchglob` requires `reset`**: Always pair `matchglob` with `reset` at
+  the end of the same action list to restore global observable values.
+- **`genasimov` once per action list**: Including it more than once causes
+  an error.
+- **Workspace name defaults**: All tools default to `combWS`/`ModelConfig`;
+  specify `-w` and `-m` explicitly if names differ.
+- **ROOT ≥ 6.18 required**: Older ROOT versions are not supported.
+
+## Interop
+
+- **workspaceCombiner**: Produces combined workspaces that quickFit operates on.
+- **xmlAnaWSBuilder / HistFactory**: Produces input workspaces; quickFit is the
+  recommended fitting tool for these.
+- **StatAnalysis**: All quickFit executables are available after
+  `asetup StatAnalysis,0.7,latest`.
+- **xRooFit**: Alternative Python/C++ API for fitting and limit setting built
+  into ROOT within StatAnalysis.
+
+## Support
+
+Contact: quickFit-user@cern.ch
+
+## Docs
+
+https://gitlab.cern.ch/atlas_higgs_combination/software/quickFit

--- a/plugins/atlas/skills/quickfit/SKILL.md
+++ b/plugins/atlas/skills/quickfit/SKILL.md
@@ -62,30 +62,30 @@ quickFit --EvalBackend=cuda -f ws.root -d dataset -p mu=1_-5_5
 
 ### Parameter syntax (`-p`)
 
-| Form | Meaning |
-|---|---|
-| `mu=1_-5_5` | Float `mu` with initial value 1, range [−5, 5] |
-| `mu=2` | Fix `mu` at 2 |
-| `mu_ggH=1_-5_5,mu_VBF=1_-5_5` | Multiple params, comma-separated |
+| Form                          | Meaning                                        |
+| ----------------------------- | ---------------------------------------------- |
+| `mu=1_-5_5`                   | Float `mu` with initial value 1, range [−5, 5] |
+| `mu=2`                        | Fix `mu` at 2                                  |
+| `mu_ggH=1_-5_5,mu_VBF=1_-5_5` | Multiple params, comma-separated               |
 
 ### Key quickFit options
 
-| Option | Description |
-|---|---|
-| `-f` | Input workspace ROOT file |
-| `-w` | Workspace name (default: `combWS`) |
-| `-m` | ModelConfig name (default: `ModelConfig`) |
-| `-d` | Dataset name to fit |
-| `-p` | POI/parameter configuration |
-| `-n` | Fix NPs matching pattern |
-| `-o` | Output ROOT file |
-| `--savefitresult` | 0 = NLL only, 1 = full RooFitResult |
-| `--hesse` | Run HESSE after MIGRAD (1=yes) |
-| `--minos` | Run MINOS (1=yes) |
-| `--useModularL` | Enable modular likelihood evaluation |
-| `--numCPU` | Number of cores for parallel evaluation |
-| `--EvalBackend` | Evaluation backend (`cpu`, `cuda`, etc.) |
-| `--minTolerance` | Minimizer tolerance |
+| Option            | Description                               |
+| ----------------- | ----------------------------------------- |
+| `-f`              | Input workspace ROOT file                 |
+| `-w`              | Workspace name (default: `combWS`)        |
+| `-m`              | ModelConfig name (default: `ModelConfig`) |
+| `-d`              | Dataset name to fit                       |
+| `-p`              | POI/parameter configuration               |
+| `-n`              | Fix NPs matching pattern                  |
+| `-o`              | Output ROOT file                          |
+| `--savefitresult` | 0 = NLL only, 1 = full RooFitResult       |
+| `--hesse`         | Run HESSE after MIGRAD (1=yes)            |
+| `--minos`         | Run MINOS (1=yes)                         |
+| `--useModularL`   | Enable modular likelihood evaluation      |
+| `--numCPU`        | Number of cores for parallel evaluation   |
+| `--EvalBackend`   | Evaluation backend (`cpu`, `cuda`, etc.)  |
+| `--minTolerance`  | Minimizer tolerance                       |
 
 ## quickAsimov — Generating Asimov Datasets
 
@@ -112,17 +112,17 @@ quickAsimov -x card.xml -w combWS -m ModelConfig -d obsData
 
 ### Action keywords (colon-separated in `Action` attribute)
 
-| Keyword | Meaning |
-|---|---|
-| `fit` | Perform maximum likelihood fit |
-| `genasimov` | Generate Asimov dataset (once per action list) |
-| `savesnapshot` | Save parameter snapshot (once per action list) |
-| `matchglob` | Match global observables to NP values (use with `reset`) |
-| `reset` | Reset parameters to state before current action list |
-| `raw` | Reset to state before any actions |
-| `fixsyst` | Fix all constrained NPs |
-| `float` | Float NPs fixed by `fixsyst` or `Setup` |
-| `<snapshot name>` | Load a saved snapshot |
+| Keyword           | Meaning                                                  |
+| ----------------- | -------------------------------------------------------- |
+| `fit`             | Perform maximum likelihood fit                           |
+| `genasimov`       | Generate Asimov dataset (once per action list)           |
+| `savesnapshot`    | Save parameter snapshot (once per action list)           |
+| `matchglob`       | Match global observables to NP values (use with `reset`) |
+| `reset`           | Reset parameters to state before current action list     |
+| `raw`             | Reset to state before any actions                        |
+| `fixsyst`         | Fix all constrained NPs                                  |
+| `float`           | Float NPs fixed by `fixsyst` or `Setup`                  |
+| `<snapshot name>` | Load a saved snapshot                                    |
 
 ## quickLimit — Asymptotic CLs Limits
 
@@ -155,8 +155,8 @@ Converts an unbinned dataset to a pseudo-binned one for faster fitting:
 quickRebin -f output.root -d toyData -o output_binned.root -r 500
 ```
 
-Creates `toyDatabinned` in the output file with 500 bins. Categories where
-the number of entries is less than the bin count remain unbinned.
+Creates `toyDatabinned` in the output file with 500 bins. Categories where the
+number of entries is less than the bin count remain unbinned.
 
 ## quickPull — NP Pull to a POI
 
@@ -173,10 +173,10 @@ quickPull -f ws.root -w combWS -d combData \
 - **Custom classes**: If the workspace uses custom RooFit classes (from
   `RooFitExtensions` or local code), ensure `LD_LIBRARY_PATH` includes the
   library directory before opening the workspace, or the program will crash.
-- **`matchglob` requires `reset`**: Always pair `matchglob` with `reset` at
-  the end of the same action list to restore global observable values.
-- **`genasimov` once per action list**: Including it more than once causes
-  an error.
+- **`matchglob` requires `reset`**: Always pair `matchglob` with `reset` at the
+  end of the same action list to restore global observable values.
+- **`genasimov` once per action list**: Including it more than once causes an
+  error.
 - **Workspace name defaults**: All tools default to `combWS`/`ModelConfig`;
   specify `-w` and `-m` explicitly if names differ.
 - **ROOT ≥ 6.18 required**: Older ROOT versions are not supported.

--- a/plugins/atlas/skills/setupatlas/SKILL.md
+++ b/plugins/atlas/skills/setupatlas/SKILL.md
@@ -244,6 +244,29 @@ ami list datasets --project mc20_13TeV --type EVNT "*Ztautau*"
 
 Contact: atlas-bookkeeping@cern.ch
 
+### MCP Servers (atlas plugin)
+
+The atlas plugin ships `.mcp.json` with three MCP servers that give Claude
+AI-accessible interfaces to ATLAS data services — no CLI invocation needed.
+
+| Server           | Tool                                    | Auth required                              | Notes                        |
+| ---------------- | --------------------------------------- | ------------------------------------------ | ---------------------------- |
+| `rucio`          | `pixi exec rucio-mcp serve --read-only` | `RUCIO_ACCOUNT` env var + valid VOMS proxy | Read-only Rucio data catalog |
+| `ami`            | `pixi exec ami-mcp serve`               | none                                       | ATLAS metadata (AMI) queries |
+| `atlasopenmagic` | `uvx atlasopenmagic-mcp serve`          | none                                       | ATLAS open data queries      |
+
+Required environment for the `rucio` server:
+
+```bash
+export RUCIO_ACCOUNT=yourusername          # required, no default
+export RUCIO_AUTH_TYPE=x509_proxy          # default; alternatives: oidc, userpass
+voms-proxy-init --voms atlas               # valid proxy required
+```
+
+These servers are installed automatically when the atlas plugin is installed.
+Users with the atlas plugin active can ask Claude to query Rucio datasets, look
+up AMI dataset metadata, or explore ATLAS open data directly in conversation.
+
 ### Utility Commands
 
 ```bash
@@ -288,6 +311,10 @@ helpMe                  # extended help with all tool documentation
 - **ATLAS analysis facilities**: setupATLAS is pre-configured on CERN lxplus,
   ATLAS AF-US, AF-UK, and SWAN; tier-3 sites that mount `/cvmfs/atlas.cern.ch`
   work identically.
+- **MCP servers**: The atlas plugin's `.mcp.json` provides `rucio-mcp` (Rucio
+  data catalog, read-only), `ami-mcp` (ATLAS metadata / AMI), and
+  `atlasopenmagic-mcp` (ATLAS open data) as AI-accessible MCP servers — see the
+  MCP Servers canonical pattern above for setup details.
 
 | Domain                                        | Mailing list                        |
 | --------------------------------------------- | ----------------------------------- |

--- a/plugins/atlas/skills/setupatlas/SKILL.md
+++ b/plugins/atlas/skills/setupatlas/SKILL.md
@@ -298,12 +298,12 @@ helpMe                  # extended help with all tool documentation
 | Atlantis event display                        | hn-atlas-AtlantisDisplay@cern.ch    |
 | AMI bookkeeping                               | atlas-bookkeeping@cern.ch           |
 
-## Additional Resources
+## Docs
+
+https://twiki.atlas-canada.ca/bin/view/AtlasCanada/ATLASLocalRootBase2
+
+### Reference Files
 
 - **`references/asetup.md`** — Complete asetup option reference, configuration
   file format, environment variables, saved session workflow, and platform
   string syntax.
-
-## Docs
-
-https://twiki.atlas-canada.ca/bin/view/AtlasCanada/ATLASLocalRootBase2

--- a/plugins/atlas/skills/setupatlas/SKILL.md
+++ b/plugins/atlas/skills/setupatlas/SKILL.md
@@ -13,14 +13,56 @@ description: >-
 
 ## Overview
 
-`setupATLAS` is the entry point to the ATLAS Local Root Base (ATLR/ALRB), a
+`setupATLAS` is the entry point to the ATLAS Local Root Base (ALRB), a
 CVMFS-based framework that provides versioned ATLAS software releases and
 individual tools. After running `setupATLAS`, the `asetup` and `lsetup` commands
 become available.
 
-## Getting the setupATLAS Command
+## When to Use
 
-On machines with CVMFS (lxplus, tier-3 sites):
+- Setting up any ATLAS software on a server with `/cvmfs/atlas.cern.ch` mounted
+  (lxplus, ATLAS analysis facilities, tier-3 sites, SWAN)
+- Getting standalone access to ROOT, rucio, panda, pyami, scikit-hep, or LCG
+  views via `lsetup` — without loading a full ATLAS release
+- Configuring a full ATLAS, Athena, AnalysisBase, or StatAnalysis software
+  release for development or analysis via `asetup`
+- Managing source packages, building with cmake, and running tests via `acm`
+- Submitting grid jobs or accessing distributed ATLAS data via rucio and panda
+- Finding the right mailing list for ATLAS software support
+
+## Key Concepts
+
+**ALRB (ATLASLocalRootBase)**: A CVMFS-based layered environment at
+`/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase`. Sourcing `atlasLocalSetup.sh`
+bootstraps the environment and exposes `asetup` and `lsetup`. The `setupATLAS`
+alias is a shorthand for this step once configured in `~/.bashrc`.
+
+**Tool categories:**
+
+| Tool category         | Command                      | Purpose                                          |
+| --------------------- | ---------------------------- | ------------------------------------------------ |
+| Environment bootstrap | `setupATLAS`                 | Sources ALRB, exposes asetup/lsetup              |
+| Individual tools      | `lsetup <tool>`              | Standalone ROOT, rucio, panda, LCG views, etc.   |
+| Full releases         | `asetup <project>,<version>` | Athena, AnalysisBase, StatAnalysis, etc.         |
+| Build system          | `acm` / `acmSetup`           | cmake/git package management on top of a release |
+| Grid tools            | `rucio`, `panda`             | Distributed data and job management              |
+
+**Session persistence**: `asetup` saves the active session to
+`$PWD/.asetup.save`. Running `asetup` with no arguments re-applies it in a new
+shell. Use `asetup --printLast` to inspect saved state.
+
+**Platform strings**: `<arch>-<os>-<compiler>-<mode>`, e.g.
+`x86_64-el9-gcc13-opt`. Controlled via `--platform`, `--os`, `--gccversion`,
+`--opt`/`--dbg` flags to `asetup`.
+
+See `references/asetup.md` for the full asetup option reference, configuration
+file format, and environment variables.
+
+## Canonical Patterns
+
+### Getting setupATLAS
+
+On servers with `/cvmfs/atlas.cern.ch` mounted (lxplus, tier-3):
 
 ```bash
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
@@ -29,19 +71,16 @@ source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
 setupATLAS
 ```
 
-On lxplus7/CentOS7 hosts that need EL9 containers:
+On lxplus7/CentOS7 hosts that need an EL9 container:
 
 ```bash
 setupATLAS -c el9
 ```
 
-Documentation:
-https://twiki.atlas-canada.ca/bin/view/AtlasCanada/ATLASLocalRootBase2
+### Setting Up Individual Tools with lsetup
 
-## lsetup — Setting Up Individual Tools
-
-`lsetup` sets up one or more individual tools in the current shell. Tools can be
-listed in sequence; use quotes for tools with version specifiers.
+`lsetup` configures one or more tools in the current shell without loading a
+full ATLAS release. Use quotes for tools with version specifiers.
 
 ```bash
 lsetup root              # latest ROOT
@@ -73,7 +112,7 @@ See all available versions with `lsetup <tool> -h` or `showVersions`.
 | `astyle`   | ATLAS ROOT style macros                | https://gitlab.cern.ch/atlas-publications-committee/atlasrootstyle |
 | `eiclient` | Event Index client                     | https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndex     |
 
-## asetup — ATLAS Software Releases
+### Configuring an ATLAS Release with asetup
 
 `asetup` configures a full ATLAS release (Athena, AnalysisBase, AnalysisTop,
 StatAnalysis, etc.) in the current shell. Arguments can be separated by spaces
@@ -119,56 +158,36 @@ Key environment variables set by `asetup`:
 
 User configuration can be stored in `~/.asetup` or `$PWD/.asetup` (INI format
 with `[defaults]`, `[aliases]`, `[environment]`, `[epilog.sh]` sections). See
-`references/asetup.md` for configuration file details.
+`references/asetup.md` for details.
 
 Quick start: https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup
 Full reference:
 https://twiki.cern.ch/twiki/bin/view/AtlasComputing/AtlasSetupReference
 
-## acm — ATLAS Package Management
+### Package Management with acm
 
-`acm` (AtlasACM) is the ATLAS cmake/git build tool. It wraps `asetup` and
-manages source checkouts, compilation, and testing. Available automatically
-after `setupATLAS`.
-
-### Setup a release with a source area
+`acm` (AtlasACM) is the ATLAS cmake/git build tool that wraps `asetup` and
+manages source checkouts, compilation, and testing.
 
 ```bash
+# Set up a release with a source area
 mkdir source build && cd build
 acmSetup --sourcearea=../source AnalysisBase,24.2,latest
 # or from a GitLab repo:
 acmSetup --sourcerepo=myuser/myrepo AthAnalysis,21.2.14
-```
 
-`acmSetup` calls `asetup`, creates `CMakeLists.txt` in the source area if
-needed, configures the cmake project, and sources `setup.sh`.
+# Restore setup in subsequent shells
+cd build && acmSetup
 
-### Subsequent setups (same release)
-
-```bash
-cd build && acmSetup   # re-sources the last setup
-```
-
-### Core acm workflow
-
-```bash
-# Add packages from athena (sparse clone first, then add)
+# Add and compile packages
 acm sparse_clone_project athena          # sparse-checkout athena
 acm add_pkg athena/Control/AthenaCommon  # include package in build
-
-# Clone an entire private fork
-acm clone_project will/MyAnalysis
+acm clone_project will/MyAnalysis        # clone entire private fork
 acm add_pkg MyAnalysis/.*               # add all packages
-
-# Compile
 acm compile                             # build everything
 acm compile_pkg MyPackage               # build single package
-
-# Create a new skeleton analysis package
-acm new_skeleton MyPackage              # creates algorithm + joboption
+acm new_skeleton MyPackage              # create skeleton analysis package
 ```
-
-### Full acm command reference
 
 | Command                           | Description                                       |
 | --------------------------------- | ------------------------------------------------- |
@@ -190,12 +209,11 @@ acm new_skeleton MyPackage              # creates algorithm + joboption
 
 Contact: atlas-sw-acm-users@cern.ch
 
-## rucio — Data Management
+### Grid Data Access (rucio, panda)
 
 ```bash
 lsetup rucio
-# Requires a valid VOMS proxy:
-voms-proxy-init --voms atlas
+voms-proxy-init --voms atlas   # required before all grid operations
 
 rucio list-dids "user.myname:*"          # list your datasets
 rucio download scope:dataset              # download a dataset
@@ -205,19 +223,17 @@ rucio add-rule scope:dataset 1 SITE_SCRATCHDISK  # create replication rule
 
 Contact: hn-atlas-dist-analysis-help@cern.ch WebUI: https://rucio-ui.cern.ch
 
-## panda — Grid Job Submission
-
 ```bash
 lsetup panda
 pathena MyJobOptions.py --inDS scope:input_dataset --outDS user.me.output
 prun --exec "my_command %IN" --inDS scope:input --outDS user.me.output
-bigpanda  # monitoring at https://bigpanda.cern.ch
+# bigpanda monitoring at https://bigpanda.cern.ch
 ```
 
-Contact: hn-atlas-dist-analysis-help@cern.ch Monitor: https://bigpanda.cern.ch
+Contact: hn-atlas-dist-analysis-help@cern.ch Monitor: https://bigpanda.cern.ch |
 Docs: https://panda-wms.readthedocs.io
 
-## pyami — Dataset Metadata
+### Dataset Metadata with pyami
 
 ```bash
 lsetup pyami
@@ -228,7 +244,7 @@ ami list datasets --project mc20_13TeV --type EVNT "*Ztautau*"
 
 Contact: atlas-bookkeeping@cern.ch
 
-## Additional Commands
+### Utility Commands
 
 ```bash
 showVersions            # show installed software versions
@@ -258,7 +274,20 @@ helpMe                  # extended help with all tool documentation
   asetup, re-sourcing with `asetup` or `acmSetup` (no arguments) re-applies the
   saved configuration.
 
-## Support Contacts
+## Interop
+
+- **StatAnalysis**: `asetup StatAnalysis,0.7,latest` gives access to xRooFit,
+  TRExFitter, cabinetry, quickFit, and the full ATLAS statistics toolkit — see
+  the statanalysis skill.
+- **xRooFit**: Available in all StatAnalysis releases via `import ROOT as XRF` —
+  see the xroofit skill.
+- **pyhf / cabinetry**: Available as Python packages within StatAnalysis — see
+  the pyhf and cabinetry skills.
+- **XRootD / fsspec-xrootd**: `lsetup xrootd` provides standalone XRootD access
+  for reading remote files — see the fsspec-xrootd skill for Python integration.
+- **ATLAS analysis facilities**: setupATLAS is pre-configured on CERN lxplus,
+  ATLAS AF-US, AF-UK, and SWAN; tier-3 sites that mount `/cvmfs/atlas.cern.ch`
+  work identically.
 
 | Domain                                        | Mailing list                        |
 | --------------------------------------------- | ----------------------------------- |

--- a/plugins/atlas/skills/setupatlas/SKILL.md
+++ b/plugins/atlas/skills/setupatlas/SKILL.md
@@ -252,7 +252,7 @@ AI-accessible interfaces to ATLAS data services — no CLI invocation needed.
 | Server           | Tool                                    | Auth required                              | Notes                        |
 | ---------------- | --------------------------------------- | ------------------------------------------ | ---------------------------- |
 | `rucio`          | `pixi exec rucio-mcp serve --read-only` | `RUCIO_ACCOUNT` env var + valid VOMS proxy | Read-only Rucio data catalog |
-| `ami`            | `pixi exec ami-mcp serve`               | none                                       | ATLAS metadata (AMI) queries |
+| `ami`            | `pixi exec ami-mcp serve`               | `~/.globus` certs + valid VOMS proxy       | ATLAS metadata (AMI) queries |
 | `atlasopenmagic` | `uvx atlasopenmagic-mcp serve`          | none                                       | ATLAS open data queries      |
 
 Required environment for the `rucio` server:

--- a/plugins/atlas/skills/setupatlas/SKILL.md
+++ b/plugins/atlas/skills/setupatlas/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: setupatlas
+description: >-
+  Use when setting up the ATLAS software environment with setupATLAS or
+  ATLASLocalRootBase, running asetup to configure an Athena or StatAnalysis
+  release, using lsetup to set up ROOT, rucio, panda, scikit-hep, LCG views,
+  or other ATLAS tools, using acm (AtlasACM) for cmake/git-based package
+  management and compilation, managing ATLAS grid middleware (rucio, panda),
+  or finding help contacts for ATLAS software support.
+---
+
+# setupATLAS
+
+## Overview
+
+`setupATLAS` is the entry point to the ATLAS Local Root Base (ATLR/ALRB),
+a CVMFS-based framework that provides versioned ATLAS software releases and
+individual tools. After running `setupATLAS`, the `asetup` and `lsetup`
+commands become available.
+
+## Getting the setupATLAS Command
+
+On machines with CVMFS (lxplus, tier-3 sites):
+
+```bash
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+# shorthand once configured in ~/.bashrc:
+setupATLAS
+```
+
+On lxplus7/CentOS7 hosts that need EL9 containers:
+
+```bash
+setupATLAS -c el9
+```
+
+Documentation: https://twiki.atlas-canada.ca/bin/view/AtlasCanada/ATLASLocalRootBase2
+
+## lsetup — Setting Up Individual Tools
+
+`lsetup` sets up one or more individual tools in the current shell. Tools
+can be listed in sequence; use quotes for tools with version specifiers.
+
+```bash
+lsetup root              # latest ROOT
+lsetup "root 6.32"       # specific ROOT version
+lsetup rucio             # Rucio distributed data management client
+lsetup panda             # PanDA client for grid job submission
+lsetup pyami             # pyAMI ATLAS metadata interface
+lsetup scikit            # scikit-hep Python ecosystem
+lsetup "views LCG_104 x86_64-el9-gcc13-opt"   # full LCG release
+lsetup xrootd            # XRootD data access protocol
+lsetup xcache            # XRootD local proxy cache
+lsetup lcgenv            # LCG environment tool
+```
+
+See all available versions with `lsetup <tool> -h` or `showVersions`.
+
+| Tool | Description | Docs / Contact |
+|---|---|---|
+| `asetup` | Athena/StatAnalysis release setup | https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup |
+| `root` | ROOT data analysis framework | https://root.cern |
+| `rucio` | Distributed data management client | https://rucio-ui.cern.ch |
+| `panda` | PanDA distributed analysis client | https://panda-wms.readthedocs.io |
+| `pyami` | ATLAS Metadata Interface Python client | https://atlas-ami.cern.ch |
+| `scikit` | scikit-hep Python ecosystem | https://scikit-hep.org |
+| `views` | Full LCG software release | `lsetup "views"` for list |
+| `xrootd` | XRootD data access | |
+| `xcache` | XRootD local proxy cache | https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Xcache |
+| `lcgenv` | LCG environment tool | https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Lcgenv |
+| `astyle` | ATLAS ROOT style macros | https://gitlab.cern.ch/atlas-publications-committee/atlasrootstyle |
+| `eiclient` | Event Index client | https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndex |
+
+## asetup — ATLAS Software Releases
+
+`asetup` configures a full ATLAS release (Athena, AnalysisBase,
+AnalysisTop, StatAnalysis, etc.) in the current shell. Arguments can be
+separated by spaces or commas.
+
+```bash
+# Stable releases
+asetup StatAnalysis,0.7.3             # specific release
+asetup AnalysisBase,24.2.2            # specific AnalysisBase release
+asetup Athena,22.0.0                  # specific Athena stable release
+
+# Latest releases
+asetup StatAnalysis,0.7,latest        # latest nightly of branch
+asetup --stable StatAnalysis,0.7,latest  # latest stable of branch
+asetup Athena,main,latest             # latest Athena main nightly
+
+# Nightly by date (rDD, rMM-DD, rYYYY-MM-DD)
+asetup Athena,main,r07-07             # nightly from July 7
+
+# Re-setup the last release saved in this directory
+asetup                                # no args = restore last session
+
+# Add a user script to be re-sourced on every restore
+asetup source myPackage/setup.sh
+
+# Undo an asetup (reset to original shell env)
+asetup --reset
+
+# Compiler/cmake only (no release)
+asetup none,gcc14,cmakesetup          # e.g. for building StatAnalysis
+```
+
+Key environment variables set by `asetup`:
+
+| Variable | Example value |
+|---|---|
+| `AtlasProject` | `Athena`, `AnalysisBase`, `StatAnalysis` |
+| `AtlasVersion` | `24.0.0` |
+| `AtlasBuildBranch` | `main`, `24.0`, `0.7` |
+| `AtlasReleaseType` | `stable` or `nightly` |
+| `BINARY_TAG` / `CMTCONFIG` | `x86_64-el9-gcc13-opt` |
+| `TestArea` | current build directory path |
+
+User configuration can be stored in `~/.asetup` or `$PWD/.asetup` (INI
+format with `[defaults]`, `[aliases]`, `[environment]`, `[epilog.sh]`
+sections). See `references/asetup.md` for configuration file details.
+
+Quick start: https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup
+Full reference: https://twiki.cern.ch/twiki/bin/view/AtlasComputing/AtlasSetupReference
+
+## acm — ATLAS Package Management
+
+`acm` (AtlasACM) is the ATLAS cmake/git build tool. It wraps `asetup` and
+manages source checkouts, compilation, and testing. Available automatically
+after `setupATLAS`.
+
+### Setup a release with a source area
+
+```bash
+mkdir source build && cd build
+acmSetup --sourcearea=../source AnalysisBase,24.2,latest
+# or from a GitLab repo:
+acmSetup --sourcerepo=myuser/myrepo AthAnalysis,21.2.14
+```
+
+`acmSetup` calls `asetup`, creates `CMakeLists.txt` in the source area if
+needed, configures the cmake project, and sources `setup.sh`.
+
+### Subsequent setups (same release)
+
+```bash
+cd build && acmSetup   # re-sources the last setup
+```
+
+### Core acm workflow
+
+```bash
+# Add packages from athena (sparse clone first, then add)
+acm sparse_clone_project athena          # sparse-checkout athena
+acm add_pkg athena/Control/AthenaCommon  # include package in build
+
+# Clone an entire private fork
+acm clone_project will/MyAnalysis
+acm add_pkg MyAnalysis/.*               # add all packages
+
+# Compile
+acm compile                             # build everything
+acm compile_pkg MyPackage               # build single package
+
+# Create a new skeleton analysis package
+acm new_skeleton MyPackage              # creates algorithm + joboption
+```
+
+### Full acm command reference
+
+| Command | Description |
+|---|---|
+| `acmSetup [opts] <release>` | Set up release + source area |
+| `acm compile` | Build project (cmake --build) |
+| `acm compile_pkg <pkg>` | Build a single package |
+| `acm find_packages` | Reconfigure cmake (wipes CMakeCache) |
+| `acm test <pkg>` | Run ctests for a package |
+| `acm clean [-f]` | cmake clean; `-f` also reruns find_packages |
+| `acm clone_project <repo>` | Clone a GitLab project into source area |
+| `acm sparse_clone_project athena` | Sparse-clone the athena project |
+| `acm add_pkg <path>` | Include package(s) in compilation |
+| `acm exclude_pkg <path>` | Exclude package(s) from compilation |
+| `acm add_pkg_clients <path>` | Add all packages that depend on the given one |
+| `acm switch <branch/tag> <path>` | Check out specific version of a package |
+| `acm new_pkg <name>` | Create a new cmake package |
+| `acm new_skeleton <name>` | Create a skeleton analysis package with algorithm |
+| `acmSetup --unset` | Undo the current setup |
+
+Contact: atlas-sw-acm-users@cern.ch
+
+## rucio — Data Management
+
+```bash
+lsetup rucio
+# Requires a valid VOMS proxy:
+voms-proxy-init --voms atlas
+
+rucio list-dids "user.myname:*"          # list your datasets
+rucio download scope:dataset              # download a dataset
+rucio upload --rse SITE_SCRATCHDISK scope:dataset file.root
+rucio add-rule scope:dataset 1 SITE_SCRATCHDISK  # create replication rule
+```
+
+Contact: hn-atlas-dist-analysis-help@cern.ch
+WebUI: https://rucio-ui.cern.ch
+
+## panda — Grid Job Submission
+
+```bash
+lsetup panda
+pathena MyJobOptions.py --inDS scope:input_dataset --outDS user.me.output
+prun --exec "my_command %IN" --inDS scope:input --outDS user.me.output
+bigpanda  # monitoring at https://bigpanda.cern.ch
+```
+
+Contact: hn-atlas-dist-analysis-help@cern.ch
+Monitor: https://bigpanda.cern.ch
+Docs: https://panda-wms.readthedocs.io
+
+## pyami — Dataset Metadata
+
+```bash
+lsetup pyami
+ami list datasets --project mc20_13TeV --type EVNT "*Ztautau*"
+# Credentials stored in ~/.pyami/pyami.cfg
+# Use --ignore-proxy to authenticate with username/password
+```
+
+Contact: atlas-bookkeeping@cern.ch
+
+## Additional Commands
+
+```bash
+showVersions            # show installed software versions
+queryC <name>           # find/query containers on CVMFS
+installPip <pkg>        # install pip package into local area
+installRpm <pkg>        # install RPM into local area
+diagnostics             # diagnostic tools menu
+advancedTools           # advanced tools menu
+printMenu               # reprint the setupATLAS menu
+helpMe                  # extended help with all tool documentation
+```
+
+## Gotchas
+
+- **No `python` alias**: `asetup` breaks if a shell alias named `python` is
+  defined. Remove it before calling `asetup`.
+- **`lsetup` vs `asetup`**: Use `lsetup root` for standalone ROOT without a
+  full release; use `asetup` when you need a compiled ATLAS release.
+- **`views` for LCG releases**: Use `lsetup "views"` (no tool name) to list
+  available LCG release names and platforms, then
+  `lsetup "views LCG_104 x86_64-el9-gcc13-opt"` to configure one.
+- **VOMS proxy required for rucio/panda**: Always run
+  `voms-proxy-init --voms atlas` before grid operations.
+- **EL9 containers on CentOS7**: Run `setupATLAS -c el9` to enter the EL9
+  container on CentOS7 hosts for branches that require EL9.
+- **Re-entering a release**: Inside a build directory configured with acm or
+  asetup, re-sourcing with `asetup` or `acmSetup` (no arguments) re-applies
+  the saved configuration.
+
+## Support Contacts
+
+| Domain | Mailing list |
+|---|---|
+| Distributed computing (rucio, panda, general) | hn-atlas-dist-analysis-help@cern.ch |
+| Physics analysis tools (PAT) | hn-atlas-PATHelp@cern.ch |
+| Offline software | hn-atlas-offlineSWHelp@cern.ch |
+| ACM package management | atlas-sw-acm-users@cern.ch |
+| Atlantis event display | hn-atlas-AtlantisDisplay@cern.ch |
+| AMI bookkeeping | atlas-bookkeeping@cern.ch |
+
+## Additional Resources
+
+- **`references/asetup.md`** — Complete asetup option reference, configuration
+  file format, environment variables, saved session workflow, and platform
+  string syntax.
+
+## Docs
+
+https://twiki.atlas-canada.ca/bin/view/AtlasCanada/ATLASLocalRootBase2

--- a/plugins/atlas/skills/setupatlas/SKILL.md
+++ b/plugins/atlas/skills/setupatlas/SKILL.md
@@ -3,20 +3,20 @@ name: setupatlas
 description: >-
   Use when setting up the ATLAS software environment with setupATLAS or
   ATLASLocalRootBase, running asetup to configure an Athena or StatAnalysis
-  release, using lsetup to set up ROOT, rucio, panda, scikit-hep, LCG views,
-  or other ATLAS tools, using acm (AtlasACM) for cmake/git-based package
-  management and compilation, managing ATLAS grid middleware (rucio, panda),
-  or finding help contacts for ATLAS software support.
+  release, using lsetup to set up ROOT, rucio, panda, scikit-hep, LCG views, or
+  other ATLAS tools, using acm (AtlasACM) for cmake/git-based package management
+  and compilation, managing ATLAS grid middleware (rucio, panda), or finding
+  help contacts for ATLAS software support.
 ---
 
 # setupATLAS
 
 ## Overview
 
-`setupATLAS` is the entry point to the ATLAS Local Root Base (ATLR/ALRB),
-a CVMFS-based framework that provides versioned ATLAS software releases and
-individual tools. After running `setupATLAS`, the `asetup` and `lsetup`
-commands become available.
+`setupATLAS` is the entry point to the ATLAS Local Root Base (ATLR/ALRB), a
+CVMFS-based framework that provides versioned ATLAS software releases and
+individual tools. After running `setupATLAS`, the `asetup` and `lsetup` commands
+become available.
 
 ## Getting the setupATLAS Command
 
@@ -35,12 +35,13 @@ On lxplus7/CentOS7 hosts that need EL9 containers:
 setupATLAS -c el9
 ```
 
-Documentation: https://twiki.atlas-canada.ca/bin/view/AtlasCanada/ATLASLocalRootBase2
+Documentation:
+https://twiki.atlas-canada.ca/bin/view/AtlasCanada/ATLASLocalRootBase2
 
 ## lsetup — Setting Up Individual Tools
 
-`lsetup` sets up one or more individual tools in the current shell. Tools
-can be listed in sequence; use quotes for tools with version specifiers.
+`lsetup` sets up one or more individual tools in the current shell. Tools can be
+listed in sequence; use quotes for tools with version specifiers.
 
 ```bash
 lsetup root              # latest ROOT
@@ -57,26 +58,26 @@ lsetup lcgenv            # LCG environment tool
 
 See all available versions with `lsetup <tool> -h` or `showVersions`.
 
-| Tool | Description | Docs / Contact |
-|---|---|---|
-| `asetup` | Athena/StatAnalysis release setup | https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup |
-| `root` | ROOT data analysis framework | https://root.cern |
-| `rucio` | Distributed data management client | https://rucio-ui.cern.ch |
-| `panda` | PanDA distributed analysis client | https://panda-wms.readthedocs.io |
-| `pyami` | ATLAS Metadata Interface Python client | https://atlas-ami.cern.ch |
-| `scikit` | scikit-hep Python ecosystem | https://scikit-hep.org |
-| `views` | Full LCG software release | `lsetup "views"` for list |
-| `xrootd` | XRootD data access | |
-| `xcache` | XRootD local proxy cache | https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Xcache |
-| `lcgenv` | LCG environment tool | https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Lcgenv |
-| `astyle` | ATLAS ROOT style macros | https://gitlab.cern.ch/atlas-publications-committee/atlasrootstyle |
-| `eiclient` | Event Index client | https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndex |
+| Tool       | Description                            | Docs / Contact                                                     |
+| ---------- | -------------------------------------- | ------------------------------------------------------------------ |
+| `asetup`   | Athena/StatAnalysis release setup      | https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup |
+| `root`     | ROOT data analysis framework           | https://root.cern                                                  |
+| `rucio`    | Distributed data management client     | https://rucio-ui.cern.ch                                           |
+| `panda`    | PanDA distributed analysis client      | https://panda-wms.readthedocs.io                                   |
+| `pyami`    | ATLAS Metadata Interface Python client | https://atlas-ami.cern.ch                                          |
+| `scikit`   | scikit-hep Python ecosystem            | https://scikit-hep.org                                             |
+| `views`    | Full LCG software release              | `lsetup "views"` for list                                          |
+| `xrootd`   | XRootD data access                     |                                                                    |
+| `xcache`   | XRootD local proxy cache               | https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Xcache          |
+| `lcgenv`   | LCG environment tool                   | https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Lcgenv          |
+| `astyle`   | ATLAS ROOT style macros                | https://gitlab.cern.ch/atlas-publications-committee/atlasrootstyle |
+| `eiclient` | Event Index client                     | https://twiki.cern.ch/twiki/bin/view/AtlasComputing/EventIndex     |
 
 ## asetup — ATLAS Software Releases
 
-`asetup` configures a full ATLAS release (Athena, AnalysisBase,
-AnalysisTop, StatAnalysis, etc.) in the current shell. Arguments can be
-separated by spaces or commas.
+`asetup` configures a full ATLAS release (Athena, AnalysisBase, AnalysisTop,
+StatAnalysis, etc.) in the current shell. Arguments can be separated by spaces
+or commas.
 
 ```bash
 # Stable releases
@@ -107,21 +108,22 @@ asetup none,gcc14,cmakesetup          # e.g. for building StatAnalysis
 
 Key environment variables set by `asetup`:
 
-| Variable | Example value |
-|---|---|
-| `AtlasProject` | `Athena`, `AnalysisBase`, `StatAnalysis` |
-| `AtlasVersion` | `24.0.0` |
-| `AtlasBuildBranch` | `main`, `24.0`, `0.7` |
-| `AtlasReleaseType` | `stable` or `nightly` |
-| `BINARY_TAG` / `CMTCONFIG` | `x86_64-el9-gcc13-opt` |
-| `TestArea` | current build directory path |
+| Variable                   | Example value                            |
+| -------------------------- | ---------------------------------------- |
+| `AtlasProject`             | `Athena`, `AnalysisBase`, `StatAnalysis` |
+| `AtlasVersion`             | `24.0.0`                                 |
+| `AtlasBuildBranch`         | `main`, `24.0`, `0.7`                    |
+| `AtlasReleaseType`         | `stable` or `nightly`                    |
+| `BINARY_TAG` / `CMTCONFIG` | `x86_64-el9-gcc13-opt`                   |
+| `TestArea`                 | current build directory path             |
 
-User configuration can be stored in `~/.asetup` or `$PWD/.asetup` (INI
-format with `[defaults]`, `[aliases]`, `[environment]`, `[epilog.sh]`
-sections). See `references/asetup.md` for configuration file details.
+User configuration can be stored in `~/.asetup` or `$PWD/.asetup` (INI format
+with `[defaults]`, `[aliases]`, `[environment]`, `[epilog.sh]` sections). See
+`references/asetup.md` for configuration file details.
 
 Quick start: https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup
-Full reference: https://twiki.cern.ch/twiki/bin/view/AtlasComputing/AtlasSetupReference
+Full reference:
+https://twiki.cern.ch/twiki/bin/view/AtlasComputing/AtlasSetupReference
 
 ## acm — ATLAS Package Management
 
@@ -168,23 +170,23 @@ acm new_skeleton MyPackage              # creates algorithm + joboption
 
 ### Full acm command reference
 
-| Command | Description |
-|---|---|
-| `acmSetup [opts] <release>` | Set up release + source area |
-| `acm compile` | Build project (cmake --build) |
-| `acm compile_pkg <pkg>` | Build a single package |
-| `acm find_packages` | Reconfigure cmake (wipes CMakeCache) |
-| `acm test <pkg>` | Run ctests for a package |
-| `acm clean [-f]` | cmake clean; `-f` also reruns find_packages |
-| `acm clone_project <repo>` | Clone a GitLab project into source area |
-| `acm sparse_clone_project athena` | Sparse-clone the athena project |
-| `acm add_pkg <path>` | Include package(s) in compilation |
-| `acm exclude_pkg <path>` | Exclude package(s) from compilation |
-| `acm add_pkg_clients <path>` | Add all packages that depend on the given one |
-| `acm switch <branch/tag> <path>` | Check out specific version of a package |
-| `acm new_pkg <name>` | Create a new cmake package |
-| `acm new_skeleton <name>` | Create a skeleton analysis package with algorithm |
-| `acmSetup --unset` | Undo the current setup |
+| Command                           | Description                                       |
+| --------------------------------- | ------------------------------------------------- |
+| `acmSetup [opts] <release>`       | Set up release + source area                      |
+| `acm compile`                     | Build project (cmake --build)                     |
+| `acm compile_pkg <pkg>`           | Build a single package                            |
+| `acm find_packages`               | Reconfigure cmake (wipes CMakeCache)              |
+| `acm test <pkg>`                  | Run ctests for a package                          |
+| `acm clean [-f]`                  | cmake clean; `-f` also reruns find_packages       |
+| `acm clone_project <repo>`        | Clone a GitLab project into source area           |
+| `acm sparse_clone_project athena` | Sparse-clone the athena project                   |
+| `acm add_pkg <path>`              | Include package(s) in compilation                 |
+| `acm exclude_pkg <path>`          | Exclude package(s) from compilation               |
+| `acm add_pkg_clients <path>`      | Add all packages that depend on the given one     |
+| `acm switch <branch/tag> <path>`  | Check out specific version of a package           |
+| `acm new_pkg <name>`              | Create a new cmake package                        |
+| `acm new_skeleton <name>`         | Create a skeleton analysis package with algorithm |
+| `acmSetup --unset`                | Undo the current setup                            |
 
 Contact: atlas-sw-acm-users@cern.ch
 
@@ -201,8 +203,7 @@ rucio upload --rse SITE_SCRATCHDISK scope:dataset file.root
 rucio add-rule scope:dataset 1 SITE_SCRATCHDISK  # create replication rule
 ```
 
-Contact: hn-atlas-dist-analysis-help@cern.ch
-WebUI: https://rucio-ui.cern.ch
+Contact: hn-atlas-dist-analysis-help@cern.ch WebUI: https://rucio-ui.cern.ch
 
 ## panda — Grid Job Submission
 
@@ -213,8 +214,7 @@ prun --exec "my_command %IN" --inDS scope:input --outDS user.me.output
 bigpanda  # monitoring at https://bigpanda.cern.ch
 ```
 
-Contact: hn-atlas-dist-analysis-help@cern.ch
-Monitor: https://bigpanda.cern.ch
+Contact: hn-atlas-dist-analysis-help@cern.ch Monitor: https://bigpanda.cern.ch
 Docs: https://panda-wms.readthedocs.io
 
 ## pyami — Dataset Metadata
@@ -245,8 +245,8 @@ helpMe                  # extended help with all tool documentation
 
 - **No `python` alias**: `asetup` breaks if a shell alias named `python` is
   defined. Remove it before calling `asetup`.
-- **`lsetup` vs `asetup`**: Use `lsetup root` for standalone ROOT without a
-  full release; use `asetup` when you need a compiled ATLAS release.
+- **`lsetup` vs `asetup`**: Use `lsetup root` for standalone ROOT without a full
+  release; use `asetup` when you need a compiled ATLAS release.
 - **`views` for LCG releases**: Use `lsetup "views"` (no tool name) to list
   available LCG release names and platforms, then
   `lsetup "views LCG_104 x86_64-el9-gcc13-opt"` to configure one.
@@ -255,19 +255,19 @@ helpMe                  # extended help with all tool documentation
 - **EL9 containers on CentOS7**: Run `setupATLAS -c el9` to enter the EL9
   container on CentOS7 hosts for branches that require EL9.
 - **Re-entering a release**: Inside a build directory configured with acm or
-  asetup, re-sourcing with `asetup` or `acmSetup` (no arguments) re-applies
-  the saved configuration.
+  asetup, re-sourcing with `asetup` or `acmSetup` (no arguments) re-applies the
+  saved configuration.
 
 ## Support Contacts
 
-| Domain | Mailing list |
-|---|---|
+| Domain                                        | Mailing list                        |
+| --------------------------------------------- | ----------------------------------- |
 | Distributed computing (rucio, panda, general) | hn-atlas-dist-analysis-help@cern.ch |
-| Physics analysis tools (PAT) | hn-atlas-PATHelp@cern.ch |
-| Offline software | hn-atlas-offlineSWHelp@cern.ch |
-| ACM package management | atlas-sw-acm-users@cern.ch |
-| Atlantis event display | hn-atlas-AtlantisDisplay@cern.ch |
-| AMI bookkeeping | atlas-bookkeeping@cern.ch |
+| Physics analysis tools (PAT)                  | hn-atlas-PATHelp@cern.ch            |
+| Offline software                              | hn-atlas-offlineSWHelp@cern.ch      |
+| ACM package management                        | atlas-sw-acm-users@cern.ch          |
+| Atlantis event display                        | hn-atlas-AtlantisDisplay@cern.ch    |
+| AMI bookkeeping                               | atlas-bookkeeping@cern.ch           |
 
 ## Additional Resources
 

--- a/plugins/atlas/skills/setupatlas/references/asetup.md
+++ b/plugins/atlas/skills/setupatlas/references/asetup.md
@@ -1,18 +1,20 @@
 # asetup Reference
 
-- Quick start guide: https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup
-- Full reference: https://twiki.cern.ch/twiki/bin/view/AtlasComputing/AtlasSetupReference
+- Quick start guide:
+  https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup
+- Full reference:
+  https://twiki.cern.ch/twiki/bin/view/AtlasComputing/AtlasSetupReference
 
 ## Release name syntax
 
-| Input | Meaning |
-|---|---|
-| `Athena,24.0.0` | stable release 24.0.0 |
-| `Athena,main,latest` | latest nightly of main branch |
-| `--stable Athena,24.0,latest` | latest stable 24.0.x |
-| `Athena,main,r07-07` | nightly from July 7 |
-| `Athena,main,r2024-07-07T2101` | exact nightly timestamp |
-| `none,gcc14,cmakesetup` | compiler+cmake only, no release |
+| Input                          | Meaning                         |
+| ------------------------------ | ------------------------------- |
+| `Athena,24.0.0`                | stable release 24.0.0           |
+| `Athena,main,latest`           | latest nightly of main branch   |
+| `--stable Athena,24.0,latest`  | latest stable 24.0.x            |
+| `Athena,main,r07-07`           | nightly from July 7             |
+| `Athena,main,r2024-07-07T2101` | exact nightly timestamp         |
+| `none,gcc14,cmakesetup`        | compiler+cmake only, no release |
 
 Tags can be comma- or space-separated.
 
@@ -52,45 +54,45 @@ source myprolog.sh
 
 ## Common asetup options
 
-| Option | Description |
-|---|---|
-| `--stable` | Restrict to stable releases only |
-| `--nightliesonly` | Restrict to nightly releases only |
-| `--reset` | Undo all asetup changes, restore original shell |
-| `--simulate` | Show what would be done without executing |
-| `--silent` / `--quiet` | Suppress all output |
-| `--printLast` | Print last saved session info for `$PWD` |
-| `--version` | Print asetup version string |
-| `--platform=<str>` | Force platform, e.g. `x86_64-el9-gcc13-opt` |
-| `--releasebase=<dir>` | Specify exact release path |
-| `--testarea=<dir>` | Set TestArea (creates CMakeLists.txt if absent) |
-| `--userpriority` | Give `[environment]` section vars higher priority |
-| `--inputconfig=None` | Skip all private config files |
-| `--helpGroup=All` | Print all available options |
-| `source <script>` | Source script and add to saved session |
+| Option                 | Description                                       |
+| ---------------------- | ------------------------------------------------- |
+| `--stable`             | Restrict to stable releases only                  |
+| `--nightliesonly`      | Restrict to nightly releases only                 |
+| `--reset`              | Undo all asetup changes, restore original shell   |
+| `--simulate`           | Show what would be done without executing         |
+| `--silent` / `--quiet` | Suppress all output                               |
+| `--printLast`          | Print last saved session info for `$PWD`          |
+| `--version`            | Print asetup version string                       |
+| `--platform=<str>`     | Force platform, e.g. `x86_64-el9-gcc13-opt`       |
+| `--releasebase=<dir>`  | Specify exact release path                        |
+| `--testarea=<dir>`     | Set TestArea (creates CMakeLists.txt if absent)   |
+| `--userpriority`       | Give `[environment]` section vars higher priority |
+| `--inputconfig=None`   | Skip all private config files                     |
+| `--helpGroup=All`      | Print all available options                       |
+| `source <script>`      | Source script and add to saved session            |
 
 ## Environment variables set by asetup
 
-| Variable | Description |
-|---|---|
-| `AtlasProject` | Project name (`Athena`, `AnalysisBase`, etc.) |
-| `AtlasVersion` | Release number found |
-| `AtlasBuildBranch` | Branch (`main`, `24.0`, `0.7`) |
-| `AtlasBuildStamp` | Build date-stamp of the release |
-| `AtlasReleaseType` | `stable` or `nightly` |
-| `AtlasArea` | Full path to the project release |
-| `AtlasBaseDir` / `ATLAS_RELEASE_BASE` | Release base directory |
-| `BINARY_TAG` / `CMTCONFIG` | Platform string (`x86_64-el9-gcc13-opt`) |
-| `LCG_RELEASE_BASE` | LCG releases base path |
-| `TestArea` | Current build directory path |
-| `MAKEFLAGS` | Set to `-j<ncores> -l<ncores>` by default |
-| `SITEROOT` | Parent of release directory |
+| Variable                              | Description                                   |
+| ------------------------------------- | --------------------------------------------- |
+| `AtlasProject`                        | Project name (`Athena`, `AnalysisBase`, etc.) |
+| `AtlasVersion`                        | Release number found                          |
+| `AtlasBuildBranch`                    | Branch (`main`, `24.0`, `0.7`)                |
+| `AtlasBuildStamp`                     | Build date-stamp of the release               |
+| `AtlasReleaseType`                    | `stable` or `nightly`                         |
+| `AtlasArea`                           | Full path to the project release              |
+| `AtlasBaseDir` / `ATLAS_RELEASE_BASE` | Release base directory                        |
+| `BINARY_TAG` / `CMTCONFIG`            | Platform string (`x86_64-el9-gcc13-opt`)      |
+| `LCG_RELEASE_BASE`                    | LCG releases base path                        |
+| `TestArea`                            | Current build directory path                  |
+| `MAKEFLAGS`                           | Set to `-j<ncores> -l<ncores>` by default     |
+| `SITEROOT`                            | Parent of release directory                   |
 
 ## Saved session
 
-asetup automatically saves session info to `$PWD/.asetup.save`. Running
-`asetup` with no arguments re-applies the last session. Use
-`asetup --printLast` to inspect what is saved.
+asetup automatically saves session info to `$PWD/.asetup.save`. Running `asetup`
+with no arguments re-applies the last session. Use `asetup --printLast` to
+inspect what is saved.
 
 ```bash
 # Save and restore workflow
@@ -103,8 +105,7 @@ asetup                                # restores last session
 
 ## Platform string
 
-Platform has four dash-separated parts:
-`<arch>-<os>-<compiler>-<mode>`
+Platform has four dash-separated parts: `<arch>-<os>-<compiler>-<mode>`
 
 Examples: `x86_64-el9-gcc13-opt`, `x86_64-slc6-gcc62-opt`
 

--- a/plugins/atlas/skills/setupatlas/references/asetup.md
+++ b/plugins/atlas/skills/setupatlas/references/asetup.md
@@ -1,0 +1,112 @@
+# asetup Reference
+
+- Quick start guide: https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/AtlasSetup
+- Full reference: https://twiki.cern.ch/twiki/bin/view/AtlasComputing/AtlasSetupReference
+
+## Release name syntax
+
+| Input | Meaning |
+|---|---|
+| `Athena,24.0.0` | stable release 24.0.0 |
+| `Athena,main,latest` | latest nightly of main branch |
+| `--stable Athena,24.0,latest` | latest stable 24.0.x |
+| `Athena,main,r07-07` | nightly from July 7 |
+| `Athena,main,r2024-07-07T2101` | exact nightly timestamp |
+| `none,gcc14,cmakesetup` | compiler+cmake only, no release |
+
+Tags can be comma- or space-separated.
+
+## Configuration files (priority order)
+
+asetup reads configuration in this order (each overrides the previous):
+
+1. Built-in asetup defaults
+2. Site config: `$AtlasSetupSiteCMake` or `$AtlasSetup/../asetupSite/.asetup`
+3. `$HOME/.asetup`
+4. `$PWD/.asetup`
+5. `--inputconfig <file>` (skips HOME and PWD files if specified)
+6. Command-line arguments (highest priority)
+
+## Configuration file format
+
+```ini
+[defaults]
+os = el9
+arch = 64
+
+[aliases]
+# alias = comma-separated tags
+sa07 = StatAnalysis,0.7,latest
+
+[environment]
+# Set before release env (unless --userpriority)
+MY_VAR = foo
+PATH = $HOME/bin:${PATH}
+
+[epilog.sh]
+source $HOME/mytools/setup.sh
+
+[prolog.sh]
+source myprolog.sh
+```
+
+## Common asetup options
+
+| Option | Description |
+|---|---|
+| `--stable` | Restrict to stable releases only |
+| `--nightliesonly` | Restrict to nightly releases only |
+| `--reset` | Undo all asetup changes, restore original shell |
+| `--simulate` | Show what would be done without executing |
+| `--silent` / `--quiet` | Suppress all output |
+| `--printLast` | Print last saved session info for `$PWD` |
+| `--version` | Print asetup version string |
+| `--platform=<str>` | Force platform, e.g. `x86_64-el9-gcc13-opt` |
+| `--releasebase=<dir>` | Specify exact release path |
+| `--testarea=<dir>` | Set TestArea (creates CMakeLists.txt if absent) |
+| `--userpriority` | Give `[environment]` section vars higher priority |
+| `--inputconfig=None` | Skip all private config files |
+| `--helpGroup=All` | Print all available options |
+| `source <script>` | Source script and add to saved session |
+
+## Environment variables set by asetup
+
+| Variable | Description |
+|---|---|
+| `AtlasProject` | Project name (`Athena`, `AnalysisBase`, etc.) |
+| `AtlasVersion` | Release number found |
+| `AtlasBuildBranch` | Branch (`main`, `24.0`, `0.7`) |
+| `AtlasBuildStamp` | Build date-stamp of the release |
+| `AtlasReleaseType` | `stable` or `nightly` |
+| `AtlasArea` | Full path to the project release |
+| `AtlasBaseDir` / `ATLAS_RELEASE_BASE` | Release base directory |
+| `BINARY_TAG` / `CMTCONFIG` | Platform string (`x86_64-el9-gcc13-opt`) |
+| `LCG_RELEASE_BASE` | LCG releases base path |
+| `TestArea` | Current build directory path |
+| `MAKEFLAGS` | Set to `-j<ncores> -l<ncores>` by default |
+| `SITEROOT` | Parent of release directory |
+
+## Saved session
+
+asetup automatically saves session info to `$PWD/.asetup.save`. Running
+`asetup` with no arguments re-applies the last session. Use
+`asetup --printLast` to inspect what is saved.
+
+```bash
+# Save and restore workflow
+cd my_build_dir
+asetup StatAnalysis,0.7,latest        # sets up and saves
+# ... later in a new shell ...
+cd my_build_dir
+asetup                                # restores last session
+```
+
+## Platform string
+
+Platform has four dash-separated parts:
+`<arch>-<os>-<compiler>-<mode>`
+
+Examples: `x86_64-el9-gcc13-opt`, `x86_64-slc6-gcc62-opt`
+
+Override with `--platform=<string>` or `--os=<os>`, `--gccversion=<ver>`,
+`--opt` / `--dbg`.

--- a/plugins/atlas/skills/statanalysis/SKILL.md
+++ b/plugins/atlas/skills/statanalysis/SKILL.md
@@ -82,21 +82,19 @@ each suite; the suite checks results against reference values.
 ### Setup on Servers with /cvmfs
 
 Works on CERN lxplus, ATLAS analysis facilities (AF-US, AF-UK, etc.), SWAN, and
-any tier-3 site with `/cvmfs/atlas.cern.ch` mounted.
+any tier-3 site with `/cvmfs/atlas.cern.ch` mounted. First make `asetup`
+available via `setupATLAS` (see the setupatlas skill for full details):
 
 ```bash
-# Make asetup available (on lxplus just run: setupATLAS)
-export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
-source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh --quiet
+setupATLAS   # or source ATLASLocalRootBase manually — see setupatlas skill
+```
 
-# Latest nightly of a branch
-asetup StatAnalysis,0.7,latest
+Then set up the desired StatAnalysis release:
 
-# Latest stable of a branch
-asetup --stable StatAnalysis,0.7,latest
-
-# Specific release
-asetup StatAnalysis,0.7.3
+```bash
+asetup StatAnalysis,0.7,latest          # latest nightly of a branch
+asetup --stable StatAnalysis,0.7,latest # latest stable of a branch
+asetup StatAnalysis,0.7.3               # specific release
 ```
 
 After setup, `$STATCHALLENGES` is automatically set to the CVMFS challenges
@@ -118,11 +116,10 @@ Tags follow the branch name (e.g. `0.7`, `0.7.3`, `main`).
 
 ### Using StatAnalysis in SWAN (Jupyter)
 
-Create a setup script containing:
+Create a SWAN session setup script with the `asetup` call for the desired branch
+(see the setupatlas skill for how to structure SWAN setup scripts):
 
 ```bash
-export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
-source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
 asetup StatAnalysis,0.7,latest
 ```
 

--- a/plugins/atlas/skills/statanalysis/SKILL.md
+++ b/plugins/atlas/skills/statanalysis/SKILL.md
@@ -21,7 +21,21 @@ and compiled external packages, available on CVMFS and as Docker images.
 
 Repository: https://gitlab.cern.ch/atlas/StatAnalysis
 
-## Branches and Platform Support
+## When to Use
+
+- Setting up a reproducible ATLAS statistics environment that includes ROOT,
+  xRooFit, TRExFitter, cabinetry, quickFit, and other tools in one `asetup` call
+- Deciding which StatAnalysis branch to use for a given ROOT version or
+  operating system (EL9 vs CentOS7)
+- Running a Docker-based StatAnalysis environment on a local machine, CI, or
+  cluster without `/cvmfs` access
+- Using SWAN (CERN Jupyter service) for interactive ATLAS statistical analysis
+- Validating a statistical toolkit implementation against the StatChallenges
+  test suite
+
+## Key Concepts
+
+### Branches and Platform Support
 
 | Branch | ROOT version | Platform      | Status          |
 | ------ | ------------ | ------------- | --------------- |
@@ -35,7 +49,36 @@ Repository: https://gitlab.cern.ch/atlas/StatAnalysis
 Use branch 0.7 for all new work. CentOS7 nodes require either `lxplus7.cern.ch`
 or `setupATLAS -c el9` to use the EL9 container.
 
-## Setup on Servers with /cvmfs
+### Included Tools
+
+| Tool               | Description                                        | Usage after asetup                               |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------ |
+| ROOT + RooFit      | Data analysis framework with statistical modelling | `import ROOT`                                    |
+| xRooFit            | High-level RooFit API (see xroofit skill)          | `import ROOT as XRF`                             |
+| TRExFitter         | HistFactory profile-likelihood fitter              | `trex-fitter <actions> config.config`            |
+| HistFitter         | Predecessor to TRExFitter, still supported         | `HistFitter.py -w -f config.py`                  |
+| cabinetry          | Python HistFactory builder and visualizer          | `import cabinetry`                               |
+| quickFit           | Rapid workspace fitting utility                    | `quickFit -f ws.root`                            |
+| quickstats         | Python statistical analysis tools                  | `import quickstats`                              |
+| RooUnfold          | Unfolding package                                  | `import ROOT; ROOT.gSystem.Load("libRooUnfold")` |
+| workspaceCombiner  | Combine HistFactory workspaces                     | `manager -w combine -x card.xml`                 |
+| xmlAnaWSBuilder    | Build workspaces from XML configurations           | `XMLReader -x config.xml`                        |
+| CMSCombine         | CMS Combine tool (for combination studies)         |                                                  |
+| CommonStatTools    | Common ATLAS statistical utilities                 |                                                  |
+| BootstrapGenerator | Bootstrap uncertainty estimation                   |                                                  |
+| RooFitExtensions   | Additional RooFit classes                          |                                                  |
+| PyAnalysis tools   | numpy, scipy, matplotlib, pandas, uproot, etc.     | `import numpy`                                   |
+
+### StatChallenges Framework
+
+StatChallenges is a pytest-based test suite for comparing statistical toolkit
+implementations. It lives at `$STATCHALLENGES` (set automatically after
+`asetup`). Implementations provide a function with the signature required by
+each suite; the suite checks results against reference values.
+
+## Canonical Patterns
+
+### Setup on Servers with /cvmfs
 
 Works on CERN lxplus, ATLAS analysis facilities (AF-US, AF-UK, etc.), SWAN, and
 any tier-3 site with `/cvmfs/atlas.cern.ch` mounted.
@@ -58,7 +101,7 @@ asetup StatAnalysis,0.7.3
 After setup, `$STATCHALLENGES` is automatically set to the CVMFS challenges
 directory.
 
-## Setup via Docker
+### Setup via Docker
 
 ```bash
 # Interactive session
@@ -72,7 +115,7 @@ docker run --pull always -e DISPLAY=host.docker.internal:0 -it \
 
 Tags follow the branch name (e.g. `0.7`, `0.7.3`, `main`).
 
-## Using StatAnalysis in SWAN (Jupyter)
+### Using StatAnalysis in SWAN (Jupyter)
 
 Create a setup script containing:
 
@@ -84,30 +127,7 @@ asetup StatAnalysis,0.7,latest
 
 Use that script as the SWAN session setup script at https://swan.cern.ch.
 
-## Included Tools
-
-| Tool               | Description                                        | Usage after asetup                               |
-| ------------------ | -------------------------------------------------- | ------------------------------------------------ |
-| ROOT + RooFit      | Data analysis framework with statistical modelling | `import ROOT`                                    |
-| xRooFit            | High-level RooFit API (see xroofit skill)          | `import ROOT as XRF`                             |
-| TRExFitter         | HistFactory profile-likelihood fitter              | `trex-fitter <actions> config.config`            |
-| HistFitter         | Predecessor to TRExFitter, still supported         | `HistFitter.py -w -f config.py`                  |
-| cabinetry          | Python HistFactory builder and visualizer          | `import cabinetry`                               |
-| quickFit           | Rapid workspace fitting utility                    | `quickFit -w ws.root`                            |
-| quickstats         | Python statistical analysis tools                  | `import quickstats`                              |
-| RooUnfold          | Unfolding package                                  | `import ROOT; ROOT.gSystem.Load("libRooUnfold")` |
-| workspaceCombiner  | Combine HistFactory workspaces                     | `workspaceCombiner ...`                          |
-| xmlAnaWSBuilder    | Build workspaces from XML configurations           |                                                  |
-| CMSCombine         | CMS Combine tool (for combination studies)         |                                                  |
-| CommonStatTools    | Common ATLAS statistical utilities                 |                                                  |
-| BootstrapGenerator | Bootstrap uncertainty estimation                   |                                                  |
-| RooFitExtensions   | Additional RooFit classes                          |                                                  |
-| PyAnalysis tools   | numpy, scipy, matplotlib, pandas, uproot, etc.     | `import numpy`                                   |
-
-## StatChallenges Framework
-
-StatChallenges is a test suite for comparing statistical toolkit
-implementations. It lives at `$STATCHALLENGES` after setup.
+### Running StatChallenges
 
 ```bash
 # List available challenge suites
@@ -133,7 +153,7 @@ the suite (shown in `--help`). The function returns a dictionary of computed
 quantities. To write a new suite, contribute to the `Challenges/suites/`
 directory of the StatAnalysis repository.
 
-## Building from Source
+### Building from Source
 
 ```bash
 # Requires modern cmake and gcc (e.g. cmake 4.0+, gcc 14.x on CVMFS)
@@ -178,11 +198,15 @@ cmake -DATLAS_BUILD_ROOT=OFF ...    # skip ROOT build (use system ROOT)
 ## Interop
 
 - **xRooFit**: Pre-compiled in all StatAnalysis releases; use
-  `import ROOT as XRF`.
+  `import ROOT as XRF`. See the xroofit skill.
 - **TRExFitter**: Available as `trex-fitter`; see the trexfitter skill.
 - **pyhf / cabinetry**: Both available as Python packages; see the pyhf and
   cabinetry skills.
+- **quickFit / workspaceCombiner / xmlAnaWSBuilder**: All available after
+  `asetup`; see the quickfit, workspacecombiner, and xmlanawsbuilder skills.
 - **uproot / awkward**: Available for Python-based I/O without ROOT.
+- **setupATLAS**: The entry point to load StatAnalysis on any server with
+  `/cvmfs/atlas.cern.ch`; see the setupatlas skill.
 
 ## Docs
 

--- a/plugins/atlas/skills/statanalysis/SKILL.md
+++ b/plugins/atlas/skills/statanalysis/SKILL.md
@@ -193,14 +193,6 @@ cmake -DATLAS_BUILD_ROOT=OFF ...    # skip ROOT build (use system ROOT)
 - **All energies in MeV**: Histograms from ATLAS reconstruction have axes in MeV
   (1 GeV = 1000 MeV). Convert explicitly if needed.
 
-## Additional Resources
-
-For detailed content beyond this overview, consult the reference files:
-
-- **`references/statchallenges-guide.md`** — Full implementation workflow
-  (writing solvers, comparing toolkits, writing new suites), test pattern
-  details, environment variables, available suites
-
 ## Interop
 
 - **xRooFit**: Pre-compiled in all StatAnalysis releases; use
@@ -213,6 +205,14 @@ For detailed content beyond this overview, consult the reference files:
 - **uproot / awkward**: Available for Python-based I/O without ROOT.
 - **setupATLAS**: The entry point to load StatAnalysis on any server with
   `/cvmfs/atlas.cern.ch`; see the setupatlas skill.
+
+## Additional Resources
+
+For detailed content beyond this overview, consult the reference files:
+
+- **`references/statchallenges-guide.md`** — Full implementation workflow
+  (writing solvers, comparing toolkits, writing new suites), test pattern
+  details, environment variables, available suites
 
 ## Docs
 

--- a/plugins/atlas/skills/statanalysis/SKILL.md
+++ b/plugins/atlas/skills/statanalysis/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: statanalysis
+description: >-
+  Use when setting up the ATLAS StatAnalysis software release with asetup,
+  choosing the right StatAnalysis branch for a given ROOT version or OS,
+  running statistical analysis tools included in StatAnalysis (xRooFit,
+  TRExFitter, HistFitter, cabinetry, quickFit, quickstats, workspaceCombiner,
+  xmlAnaWSBuilder, RooUnfold, CMSCombine), using StatAnalysis Docker images,
+  building StatAnalysis from source, or using the StatChallenges framework to
+  compare toolkit implementations.
+---
+
+# StatAnalysis
+
+## Overview
+
+StatAnalysis is an ATLAS software release that bundles all commonly-used
+statistical analysis tools into a single, versioned environment managed by the
+ATLAS build system (AtlasCmake). It provides a consistent ROOT version,
+Python, and compiled external packages, available on CVMFS and as Docker
+images.
+
+Repository: https://gitlab.cern.ch/atlas/StatAnalysis
+
+## Branches and Platform Support
+
+| Branch | ROOT version | Platform | Status |
+|---|---|---|---|
+| 0.7 | 6.38 | EL9 only | **Recommended** |
+| 0.6 | 6.36 | EL9 only | Phasing out |
+| 0.5 | 6.34 | EL9 only | Phasing out |
+| 0.4 | 6.32 | EL9 only | Deprecated |
+| 0.3 | 6.30 | EL9 + CentOS7 | Deprecated |
+| 0.2 | 6.28 | CentOS7 only | Deprecated |
+
+Use branch 0.7 for all new work. CentOS7 nodes require either
+`lxplus7.cern.ch` or `setupATLAS -c el9` to use the EL9 container.
+
+## Setup on CVMFS
+
+```bash
+# Make asetup available (on lxplus just run: setupATLAS)
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh --quiet
+
+# Latest nightly of a branch
+asetup StatAnalysis,0.7,latest
+
+# Latest stable of a branch
+asetup --stable StatAnalysis,0.7,latest
+
+# Specific release
+asetup StatAnalysis,0.7.3
+```
+
+After setup, `$STATCHALLENGES` is automatically set to the CVMFS challenges
+directory.
+
+## Setup via Docker
+
+```bash
+# Interactive session
+docker run --pull always -it gitlab-registry.cern.ch/atlas/statanalysis:0.7
+
+# With X11 forwarding (macOS)
+xhost +${hostname}
+docker run --pull always -e DISPLAY=host.docker.internal:0 -it \
+    gitlab-registry.cern.ch/atlas/statanalysis:0.7
+```
+
+Tags follow the branch name (e.g. `0.7`, `0.7.3`, `main`).
+
+## Using StatAnalysis in SWAN (Jupyter)
+
+Create a setup script containing:
+
+```bash
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+asetup StatAnalysis,0.7,latest
+```
+
+Use that script as the SWAN session setup script at https://swan.cern.ch.
+
+## Included Tools
+
+| Tool | Description | Usage after asetup |
+|---|---|---|
+| ROOT + RooFit | Data analysis framework with statistical modelling | `import ROOT` |
+| xRooFit | High-level RooFit API (see xroofit skill) | `import ROOT as XRF` |
+| TRExFitter | HistFactory profile-likelihood fitter | `trex-fitter <actions> config.config` |
+| HistFitter | Predecessor to TRExFitter, still supported | `HistFitter.py -w -f config.py` |
+| cabinetry | Python HistFactory builder and visualizer | `import cabinetry` |
+| quickFit | Rapid workspace fitting utility | `quickFit -w ws.root` |
+| quickstats | Python statistical analysis tools | `import quickstats` |
+| RooUnfold | Unfolding package | `import ROOT; ROOT.gSystem.Load("libRooUnfold")` |
+| workspaceCombiner | Combine HistFactory workspaces | `workspaceCombiner ...` |
+| xmlAnaWSBuilder | Build workspaces from XML configurations | |
+| CMSCombine | CMS Combine tool (for combination studies) | |
+| CommonStatTools | Common ATLAS statistical utilities | |
+| BootstrapGenerator | Bootstrap uncertainty estimation | |
+| RooFitExtensions | Additional RooFit classes | |
+| PyAnalysis tools | numpy, scipy, matplotlib, pandas, uproot, etc. | `import numpy` |
+
+## StatChallenges Framework
+
+StatChallenges is a test suite for comparing statistical toolkit
+implementations. It lives at `$STATCHALLENGES` after setup.
+
+```bash
+# List available challenge suites
+pytest $STATCHALLENGES --ls
+
+# See the requirements for a suite
+pytest $STATCHALLENGES/suites/test_hist.py --help
+
+# Run your implementation against a suite
+pytest $STATCHALLENGES/suites/test_hist.py --impls my_impl.py
+
+# Compare multiple implementations
+pytest $STATCHALLENGES/suites/test_hist.py \
+    --impls my_impl.py,xRooFit.py
+
+# Use central release, no clone needed
+setupATLAS && asetup StatAnalysis,latest,main
+# $STATCHALLENGES already set to CVMFS directory
+```
+
+An implementation file defines a function with the exact signature required
+by the suite (shown in `--help`). The function returns a dictionary of
+computed quantities. To write a new suite, contribute to the
+`Challenges/suites/` directory of the StatAnalysis repository.
+
+## Building from Source
+
+```bash
+# Requires modern cmake and gcc (e.g. cmake 4.0+, gcc 14.x on CVMFS)
+asetup none,gcc14,cmakesetup   # on CVMFS
+git clone --recurse-submodules https://gitlab.cern.ch/atlas/StatAnalysis.git
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=../install ../StatAnalysis
+make -j install
+source ../install/setup.sh
+```
+
+Build time is ~1 hour for a full build. Use the tier1 Docker image to reduce
+to ~10 minutes when only changing packages other than ROOT:
+
+```bash
+docker run --pull always -it gitlab-registry.cern.ch/atlas/statanalysis:0.7_tier1
+```
+
+Control which components are built:
+
+```bash
+cmake -LAH ./ | grep ATLAS_BUILD_   # list build options
+cmake -LAH ./ | grep STATANA_       # list version options
+cmake -DATLAS_BUILD_ROOT=OFF ...    # skip ROOT build (use system ROOT)
+```
+
+## Gotchas
+
+- **No `python` alias allowed**: `asetup` fails if a shell alias named
+  `python` is defined. Remove any such alias before running `asetup`.
+- **CentOS7 compatibility**: Branches 0.4+ are EL9-only. Use
+  `setupATLAS -c el9` on CentOS7 hosts to enter the EL9 container, or use
+  `lxplus7.cern.ch` only for the 0.2 branch.
+- **KRB5 authentication for source builds**: The default checkout method uses
+  Kerberos. Run `kinit` first, or add
+  `-DCERN_GITLAB_PREFIX="ssh://git@gitlab.cern.ch:7999"` for SSH access.
+- **macOS builds require openssl@1.1**: Python's ssl module depends on it.
+  Install with `brew install openssl@1.1` and copy the pkg-config files.
+- **All energies in MeV**: Histograms from ATLAS reconstruction have axes in
+  MeV (1 GeV = 1000 MeV). Convert explicitly if needed.
+
+## Interop
+
+- **xRooFit**: Pre-compiled in all StatAnalysis releases; use
+  `import ROOT as XRF`.
+- **TRExFitter**: Available as `trex-fitter`; see the trexfitter skill.
+- **pyhf / cabinetry**: Both available as Python packages; see the pyhf and
+  cabinetry skills.
+- **uproot / awkward**: Available for Python-based I/O without ROOT.
+
+## Docs
+
+https://gitlab.cern.ch/atlas/StatAnalysis

--- a/plugins/atlas/skills/statanalysis/SKILL.md
+++ b/plugins/atlas/skills/statanalysis/SKILL.md
@@ -51,23 +51,24 @@ or `setupATLAS -c el9` to use the EL9 container.
 
 ### Included Tools
 
-| Tool               | Description                                        | Usage after asetup                               |
-| ------------------ | -------------------------------------------------- | ------------------------------------------------ |
-| ROOT + RooFit      | Data analysis framework with statistical modelling | `import ROOT`                                    |
-| xRooFit            | High-level RooFit API (see xroofit skill)          | `import ROOT as XRF`                             |
-| TRExFitter         | HistFactory profile-likelihood fitter              | `trex-fitter <actions> config.config`            |
-| HistFitter         | Predecessor to TRExFitter, still supported         | `HistFitter.py -w -f config.py`                  |
-| cabinetry          | Python HistFactory builder and visualizer          | `import cabinetry`                               |
-| quickFit           | Rapid workspace fitting utility                    | `quickFit -f ws.root`                            |
-| quickstats         | Python statistical analysis tools                  | `import quickstats`                              |
-| RooUnfold          | Unfolding package                                  | `import ROOT; ROOT.gSystem.Load("libRooUnfold")` |
-| workspaceCombiner  | Combine HistFactory workspaces                     | `manager -w combine -x card.xml`                 |
-| xmlAnaWSBuilder    | Build workspaces from XML configurations           | `XMLReader -x config.xml`                        |
-| CMSCombine         | CMS Combine tool (for combination studies)         |                                                  |
-| CommonStatTools    | Common ATLAS statistical utilities                 |                                                  |
-| BootstrapGenerator | Bootstrap uncertainty estimation                   |                                                  |
-| RooFitExtensions   | Additional RooFit classes                          |                                                  |
-| PyAnalysis tools   | numpy, scipy, matplotlib, pandas, uproot, etc.     | `import numpy`                                   |
+| Tool                    | Description                                        | Usage after asetup                               |
+| ----------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| ROOT + RooFit           | Data analysis framework with statistical modelling | `import ROOT`                                    |
+| xRooFit                 | High-level RooFit API (see xroofit skill)          | `import ROOT as XRF`                             |
+| TRExFitter              | HistFactory profile-likelihood fitter              | `trex-fitter <actions> config.config`            |
+| HistFitter              | Predecessor to TRExFitter, still supported         | `HistFitter.py -w -f config.py`                  |
+| cabinetry               | Python HistFactory builder and visualizer          | `import cabinetry`                               |
+| quickFit                | Rapid workspace fitting utility                    | `quickFit -f ws.root`                            |
+| quickstats              | Python statistical analysis tools                  | `import quickstats`                              |
+| RooUnfold               | Unfolding package                                  | `import ROOT; ROOT.gSystem.Load("libRooUnfold")` |
+| workspaceCombiner       | Combine HistFactory workspaces                     | `manager -w combine -x card.xml`                 |
+| xmlAnaWSBuilder         | Build workspaces from XML configurations           | `XMLReader -x config.xml`                        |
+| CMSCombine              | CMS Combine tool (for combination studies)         |                                                  |
+| CommonStatTools         | Common ATLAS statistical utilities                 |                                                  |
+| BootstrapGenerator      | Bootstrap uncertainty estimation                   |                                                  |
+| RooFitExtensions        | Additional RooFit classes                          |                                                  |
+| SystematicSmoothingTool | Smoothing tool for systematic variations           |                                                  |
+| PyAnalysis tools        | numpy, scipy, matplotlib, pandas, uproot, etc.     | `import numpy`                                   |
 
 ### StatChallenges Framework
 
@@ -194,6 +195,14 @@ cmake -DATLAS_BUILD_ROOT=OFF ...    # skip ROOT build (use system ROOT)
   Install with `brew install openssl@1.1` and copy the pkg-config files.
 - **All energies in MeV**: Histograms from ATLAS reconstruction have axes in MeV
   (1 GeV = 1000 MeV). Convert explicitly if needed.
+
+## Additional Resources
+
+For detailed content beyond this overview, consult the reference files:
+
+- **`references/statchallenges-guide.md`** — Full implementation workflow
+  (writing solvers, comparing toolkits, writing new suites), test pattern
+  details, environment variables, available suites
 
 ## Interop
 

--- a/plugins/atlas/skills/statanalysis/SKILL.md
+++ b/plugins/atlas/skills/statanalysis/SKILL.md
@@ -206,14 +206,14 @@ cmake -DATLAS_BUILD_ROOT=OFF ...    # skip ROOT build (use system ROOT)
 - **setupATLAS**: The entry point to load StatAnalysis on any server with
   `/cvmfs/atlas.cern.ch`; see the setupatlas skill.
 
-## Additional Resources
+## Docs
+
+https://gitlab.cern.ch/atlas/StatAnalysis
+
+### Additional Resources
 
 For detailed content beyond this overview, consult the reference files:
 
 - **`references/statchallenges-guide.md`** — Full implementation workflow
   (writing solvers, comparing toolkits, writing new suites), test pattern
   details, environment variables, available suites
-
-## Docs
-
-https://gitlab.cern.ch/atlas/StatAnalysis

--- a/plugins/atlas/skills/statanalysis/SKILL.md
+++ b/plugins/atlas/skills/statanalysis/SKILL.md
@@ -2,9 +2,9 @@
 name: statanalysis
 description: >-
   Use when setting up the ATLAS StatAnalysis software release with asetup,
-  choosing the right StatAnalysis branch for a given ROOT version or OS,
-  running statistical analysis tools included in StatAnalysis (xRooFit,
-  TRExFitter, HistFitter, cabinetry, quickFit, quickstats, workspaceCombiner,
+  choosing the right StatAnalysis branch for a given ROOT version or OS, running
+  statistical analysis tools included in StatAnalysis (xRooFit, TRExFitter,
+  HistFitter, cabinetry, quickFit, quickstats, workspaceCombiner,
   xmlAnaWSBuilder, RooUnfold, CMSCombine), using StatAnalysis Docker images,
   building StatAnalysis from source, or using the StatChallenges framework to
   compare toolkit implementations.
@@ -16,27 +16,29 @@ description: >-
 
 StatAnalysis is an ATLAS software release that bundles all commonly-used
 statistical analysis tools into a single, versioned environment managed by the
-ATLAS build system (AtlasCmake). It provides a consistent ROOT version,
-Python, and compiled external packages, available on CVMFS and as Docker
-images.
+ATLAS build system (AtlasCmake). It provides a consistent ROOT version, Python,
+and compiled external packages, available on CVMFS and as Docker images.
 
 Repository: https://gitlab.cern.ch/atlas/StatAnalysis
 
 ## Branches and Platform Support
 
-| Branch | ROOT version | Platform | Status |
-|---|---|---|---|
-| 0.7 | 6.38 | EL9 only | **Recommended** |
-| 0.6 | 6.36 | EL9 only | Phasing out |
-| 0.5 | 6.34 | EL9 only | Phasing out |
-| 0.4 | 6.32 | EL9 only | Deprecated |
-| 0.3 | 6.30 | EL9 + CentOS7 | Deprecated |
-| 0.2 | 6.28 | CentOS7 only | Deprecated |
+| Branch | ROOT version | Platform      | Status          |
+| ------ | ------------ | ------------- | --------------- |
+| 0.7    | 6.38         | EL9 only      | **Recommended** |
+| 0.6    | 6.36         | EL9 only      | Phasing out     |
+| 0.5    | 6.34         | EL9 only      | Phasing out     |
+| 0.4    | 6.32         | EL9 only      | Deprecated      |
+| 0.3    | 6.30         | EL9 + CentOS7 | Deprecated      |
+| 0.2    | 6.28         | CentOS7 only  | Deprecated      |
 
-Use branch 0.7 for all new work. CentOS7 nodes require either
-`lxplus7.cern.ch` or `setupATLAS -c el9` to use the EL9 container.
+Use branch 0.7 for all new work. CentOS7 nodes require either `lxplus7.cern.ch`
+or `setupATLAS -c el9` to use the EL9 container.
 
-## Setup on CVMFS
+## Setup on Servers with /cvmfs
+
+Works on CERN lxplus, ATLAS analysis facilities (AF-US, AF-UK, etc.), SWAN, and
+any tier-3 site with `/cvmfs/atlas.cern.ch` mounted.
 
 ```bash
 # Make asetup available (on lxplus just run: setupATLAS)
@@ -84,23 +86,23 @@ Use that script as the SWAN session setup script at https://swan.cern.ch.
 
 ## Included Tools
 
-| Tool | Description | Usage after asetup |
-|---|---|---|
-| ROOT + RooFit | Data analysis framework with statistical modelling | `import ROOT` |
-| xRooFit | High-level RooFit API (see xroofit skill) | `import ROOT as XRF` |
-| TRExFitter | HistFactory profile-likelihood fitter | `trex-fitter <actions> config.config` |
-| HistFitter | Predecessor to TRExFitter, still supported | `HistFitter.py -w -f config.py` |
-| cabinetry | Python HistFactory builder and visualizer | `import cabinetry` |
-| quickFit | Rapid workspace fitting utility | `quickFit -w ws.root` |
-| quickstats | Python statistical analysis tools | `import quickstats` |
-| RooUnfold | Unfolding package | `import ROOT; ROOT.gSystem.Load("libRooUnfold")` |
-| workspaceCombiner | Combine HistFactory workspaces | `workspaceCombiner ...` |
-| xmlAnaWSBuilder | Build workspaces from XML configurations | |
-| CMSCombine | CMS Combine tool (for combination studies) | |
-| CommonStatTools | Common ATLAS statistical utilities | |
-| BootstrapGenerator | Bootstrap uncertainty estimation | |
-| RooFitExtensions | Additional RooFit classes | |
-| PyAnalysis tools | numpy, scipy, matplotlib, pandas, uproot, etc. | `import numpy` |
+| Tool               | Description                                        | Usage after asetup                               |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------ |
+| ROOT + RooFit      | Data analysis framework with statistical modelling | `import ROOT`                                    |
+| xRooFit            | High-level RooFit API (see xroofit skill)          | `import ROOT as XRF`                             |
+| TRExFitter         | HistFactory profile-likelihood fitter              | `trex-fitter <actions> config.config`            |
+| HistFitter         | Predecessor to TRExFitter, still supported         | `HistFitter.py -w -f config.py`                  |
+| cabinetry          | Python HistFactory builder and visualizer          | `import cabinetry`                               |
+| quickFit           | Rapid workspace fitting utility                    | `quickFit -w ws.root`                            |
+| quickstats         | Python statistical analysis tools                  | `import quickstats`                              |
+| RooUnfold          | Unfolding package                                  | `import ROOT; ROOT.gSystem.Load("libRooUnfold")` |
+| workspaceCombiner  | Combine HistFactory workspaces                     | `workspaceCombiner ...`                          |
+| xmlAnaWSBuilder    | Build workspaces from XML configurations           |                                                  |
+| CMSCombine         | CMS Combine tool (for combination studies)         |                                                  |
+| CommonStatTools    | Common ATLAS statistical utilities                 |                                                  |
+| BootstrapGenerator | Bootstrap uncertainty estimation                   |                                                  |
+| RooFitExtensions   | Additional RooFit classes                          |                                                  |
+| PyAnalysis tools   | numpy, scipy, matplotlib, pandas, uproot, etc.     | `import numpy`                                   |
 
 ## StatChallenges Framework
 
@@ -126,10 +128,10 @@ setupATLAS && asetup StatAnalysis,latest,main
 # $STATCHALLENGES already set to CVMFS directory
 ```
 
-An implementation file defines a function with the exact signature required
-by the suite (shown in `--help`). The function returns a dictionary of
-computed quantities. To write a new suite, contribute to the
-`Challenges/suites/` directory of the StatAnalysis repository.
+An implementation file defines a function with the exact signature required by
+the suite (shown in `--help`). The function returns a dictionary of computed
+quantities. To write a new suite, contribute to the `Challenges/suites/`
+directory of the StatAnalysis repository.
 
 ## Building from Source
 
@@ -143,8 +145,8 @@ make -j install
 source ../install/setup.sh
 ```
 
-Build time is ~1 hour for a full build. Use the tier1 Docker image to reduce
-to ~10 minutes when only changing packages other than ROOT:
+Build time is ~1 hour for a full build. Use the tier1 Docker image to reduce to
+~10 minutes when only changing packages other than ROOT:
 
 ```bash
 docker run --pull always -it gitlab-registry.cern.ch/atlas/statanalysis:0.7_tier1
@@ -160,18 +162,18 @@ cmake -DATLAS_BUILD_ROOT=OFF ...    # skip ROOT build (use system ROOT)
 
 ## Gotchas
 
-- **No `python` alias allowed**: `asetup` fails if a shell alias named
-  `python` is defined. Remove any such alias before running `asetup`.
-- **CentOS7 compatibility**: Branches 0.4+ are EL9-only. Use
-  `setupATLAS -c el9` on CentOS7 hosts to enter the EL9 container, or use
-  `lxplus7.cern.ch` only for the 0.2 branch.
+- **No `python` alias allowed**: `asetup` fails if a shell alias named `python`
+  is defined. Remove any such alias before running `asetup`.
+- **CentOS7 compatibility**: Branches 0.4+ are EL9-only. Use `setupATLAS -c el9`
+  on CentOS7 hosts to enter the EL9 container, or use `lxplus7.cern.ch` only for
+  the 0.2 branch.
 - **KRB5 authentication for source builds**: The default checkout method uses
   Kerberos. Run `kinit` first, or add
   `-DCERN_GITLAB_PREFIX="ssh://git@gitlab.cern.ch:7999"` for SSH access.
 - **macOS builds require openssl@1.1**: Python's ssl module depends on it.
   Install with `brew install openssl@1.1` and copy the pkg-config files.
-- **All energies in MeV**: Histograms from ATLAS reconstruction have axes in
-  MeV (1 GeV = 1000 MeV). Convert explicitly if needed.
+- **All energies in MeV**: Histograms from ATLAS reconstruction have axes in MeV
+  (1 GeV = 1000 MeV). Convert explicitly if needed.
 
 ## Interop
 

--- a/plugins/atlas/skills/statanalysis/references/statchallenges-guide.md
+++ b/plugins/atlas/skills/statanalysis/references/statchallenges-guide.md
@@ -1,9 +1,8 @@
 # StatChallenges Implementation Guide
 
-StatChallenges is a pytest-based framework for comparing statistical
-toolkit implementations. It lives in the StatAnalysis repository under
-`Challenges/` and is installed to `$STATCHALLENGES` (set automatically
-after `asetup`).
+StatChallenges is a pytest-based framework for comparing statistical toolkit
+implementations. It lives in the StatAnalysis repository under `Challenges/` and
+is installed to `$STATCHALLENGES` (set automatically after `asetup`).
 
 ## Writing an Implementation
 
@@ -23,14 +22,14 @@ asetup StatAnalysis,latest,main
 pytest $STATCHALLENGES/suites/test_hist.py --help
 ```
 
-This prints the required function signature, parameters, and return
-dictionary keys.
+This prints the required function signature, parameters, and return dictionary
+keys.
 
 ### Step 3: Write the Solver
 
-Create a local Python file (e.g., `my_toolkit_impl.py`). Define the
-required function with the exact signature from `--help`. The function
-must return a dictionary of computed quantities.
+Create a local Python file (e.g., `my_toolkit_impl.py`). Define the required
+function with the exact signature from `--help`. The function must return a
+dictionary of computed quantities.
 
 Example skeleton for `test_hist.py`:
 
@@ -76,11 +75,11 @@ pytest $STATCHALLENGES/suites/test_hist.py \
 Implementation files may be:
 
 - Local files (path to `.py`)
-- Installed implementations (discovered from `STATANA_IMPL_DIR` or
-  `DATAPATH` environment variables)
+- Installed implementations (discovered from `STATANA_IMPL_DIR` or `DATAPATH`
+  environment variables)
 
-Comparison mode is essential for test answers that lack a reference
-value — passing is based on whether the answer matches the majority.
+Comparison mode is essential for test answers that lack a reference value —
+passing is based on whether the answer matches the majority.
 
 ## Available Suites
 
@@ -92,12 +91,12 @@ pytest $STATCHALLENGES --ls
 
 Current suites include:
 
-- **test_2bin**: Simple two-bin model with post-fit μ calculation.
-  Function: `compute_postfit_mu(bkg_yield, sig_yield_nominal,
-  observed_events)` → `{"mu_hat", "mu_hat_err"}`
-- **test_hist**: Multi-bin histogram model with limit calculation.
-  Function: `compute_simple_histogram_model_limit(hist_file_path)` →
-  yields, uncertainties, NLL values, CLs limits
+- **test_2bin**: Simple two-bin model with post-fit μ calculation. Function:
+  `compute_postfit_mu(bkg_yield, sig_yield_nominal, observed_events)` →
+  `{"mu_hat", "mu_hat_err"}`
+- **test_hist**: Multi-bin histogram model with limit calculation. Function:
+  `compute_simple_histogram_model_limit(hist_file_path)` → yields,
+  uncertainties, NLL values, CLs limits
 
 ## Test Result Evaluation
 
@@ -155,11 +154,11 @@ def test_my_test():
 
 - Test functions must start with `test_` and return a dictionary with
   `"subject_fn"`, `"args"`, and `"solution"` keys
-- The `"solution"` is a callable that receives the same args and returns
-  the reference dictionary. Set to `None` if no analytic reference
-  exists (comparison mode only)
-- Use Python docstrings extensively — the framework extracts them to
-  generate the `--help` output
+- The `"solution"` is a callable that receives the same args and returns the
+  reference dictionary. Set to `None` if no analytic reference exists
+  (comparison mode only)
+- Use Python docstrings extensively — the framework extracts them to generate
+  the `--help` output
 
 ### Step 3: Test Locally
 
@@ -169,8 +168,8 @@ pytest $STATCHALLENGES/suites/test_my_challenge.py --impls my_impl.py
 
 ## Environment Variables
 
-| Variable             | Description |
-| -------------------- | ----------- |
-| `STATCHALLENGES`     | Path to challenges directory (set automatically by asetup) |
-| `STATANA_IMPL_DIR`   | Additional directories to search for implementation files |
-| `PRIMARY_IMPL`       | If set, only this implementation's results affect exit status |
+| Variable           | Description                                                   |
+| ------------------ | ------------------------------------------------------------- |
+| `STATCHALLENGES`   | Path to challenges directory (set automatically by asetup)    |
+| `STATANA_IMPL_DIR` | Additional directories to search for implementation files     |
+| `PRIMARY_IMPL`     | If set, only this implementation's results affect exit status |

--- a/plugins/atlas/skills/statanalysis/references/statchallenges-guide.md
+++ b/plugins/atlas/skills/statanalysis/references/statchallenges-guide.md
@@ -1,0 +1,176 @@
+# StatChallenges Implementation Guide
+
+StatChallenges is a pytest-based framework for comparing statistical
+toolkit implementations. It lives in the StatAnalysis repository under
+`Challenges/` and is installed to `$STATCHALLENGES` (set automatically
+after `asetup`).
+
+## Writing an Implementation
+
+No repository clone is needed — use the central release on CVMFS.
+
+### Step 1: Setup
+
+```bash
+setupATLAS
+asetup StatAnalysis,latest,main
+# $STATCHALLENGES is now set to the CVMFS challenges directory
+```
+
+### Step 2: Read Suite Requirements
+
+```bash
+pytest $STATCHALLENGES/suites/test_hist.py --help
+```
+
+This prints the required function signature, parameters, and return
+dictionary keys.
+
+### Step 3: Write the Solver
+
+Create a local Python file (e.g., `my_toolkit_impl.py`). Define the
+required function with the exact signature from `--help`. The function
+must return a dictionary of computed quantities.
+
+Example skeleton for `test_hist.py`:
+
+```python
+def compute_simple_histogram_model_limit(hist_file_path):
+    """
+    hist_file_path: path to a ROOT file containing histograms
+    with naming convention <Region>/<Sample>/<Variation>.
+    <Variation>="Nominal" for nominal, <Sample>="Data" for
+    observed data. Variations with only _Up or _Down should
+    be symmetrized. The "Signal" sample is scaled by a
+    signal strength POI, mu.
+
+    Returns a dictionary with keys:
+      "yield_b", "yield_b_err", "yield_b_err_up",
+      "yield_b_err_down",
+      "yield_b_alpha_WeightBasedModeling_0p5",
+      "yield_s", "yield_s_err",
+      "dnll_alpha_WeightBasedModeling_0p5",
+      "cls_obs_limit", "cls_obs_lim_err",
+      "cls_exp_lim", "cls_exp_lim_err",
+      "cls_1sig_lim", "cls_1sig_lim_err"
+    """
+    # Implementation here
+    return {...}
+```
+
+### Step 4: Test
+
+```bash
+pytest $STATCHALLENGES/suites/test_hist.py --impls my_toolkit_impl.py
+```
+
+## Comparing Multiple Implementations
+
+Run multiple implementations together to compare results:
+
+```bash
+pytest $STATCHALLENGES/suites/test_hist.py \
+    --impls my_impl.py,xRooFit.py
+```
+
+Implementation files may be:
+
+- Local files (path to `.py`)
+- Installed implementations (discovered from `STATANA_IMPL_DIR` or
+  `DATAPATH` environment variables)
+
+Comparison mode is essential for test answers that lack a reference
+value — passing is based on whether the answer matches the majority.
+
+## Available Suites
+
+List all discovered suites:
+
+```bash
+pytest $STATCHALLENGES --ls
+```
+
+Current suites include:
+
+- **test_2bin**: Simple two-bin model with post-fit μ calculation.
+  Function: `compute_postfit_mu(bkg_yield, sig_yield_nominal,
+  observed_events)` → `{"mu_hat", "mu_hat_err"}`
+- **test_hist**: Multi-bin histogram model with limit calculation.
+  Function: `compute_simple_histogram_model_limit(hist_file_path)` →
+  yields, uncertainties, NLL values, CLs limits
+
+## Test Result Evaluation
+
+Results are compared using `math.isclose` with `rel_tol=1e-3` and
+`abs_tol=1e-3`. The framework produces:
+
+- **Pass**: value matches reference (or majority)
+- **Fail**: value differs or key is missing
+- **Observed**: no reference available, recorded for comparison
+
+JUnit XML reports are written to `test-reports/junit-report.xml`.
+
+## Writing a New Test Suite
+
+Contributing a new suite requires cloning the StatAnalysis repository.
+
+### Step 1: Clone and Override
+
+```bash
+setupATLAS
+asetup StatAnalysis,latest,main
+git clone https://gitlab.cern.ch/atlas/StatAnalysis.git
+cd StatAnalysis
+export STATCHALLENGES=$PWD/Challenges
+```
+
+### Step 2: Create the Suite
+
+Create `Challenges/suites/test_my_challenge.py` following this pattern:
+
+```python
+import sys
+
+def test_my_test():
+    """
+    Describe the challenge.
+
+    Implement function_name(arg1, arg2) that returns a
+    dictionary of answers.
+    """
+    arg1 = "some_input"
+    arg2 = 42
+
+    def reference_solution(arg1, arg2):
+        return {"answer1": 3.14, "answer2": 2.72}
+
+    return {
+        "subject_fn": "function_name",
+        "args": [arg1, arg2],
+        "solution": reference_solution,
+    }
+```
+
+### Key Points
+
+- Test functions must start with `test_` and return a dictionary with
+  `"subject_fn"`, `"args"`, and `"solution"` keys
+- The `"solution"` is a callable that receives the same args and returns
+  the reference dictionary. Set to `None` if no analytic reference
+  exists (comparison mode only)
+- Use Python docstrings extensively — the framework extracts them to
+  generate the `--help` output
+
+### Step 3: Test Locally
+
+```bash
+pytest $STATCHALLENGES/suites/test_my_challenge.py --impls my_impl.py
+```
+
+## Environment Variables
+
+| Variable             | Description |
+| -------------------- | ----------- |
+| `STATCHALLENGES`     | Path to challenges directory (set automatically by asetup) |
+| `STATANA_IMPL_DIR`   | Additional directories to search for implementation files |
+| `PRIMARY_IMPL`       | If set, only this implementation's results affect exit status |

--- a/plugins/atlas/skills/uproot/SKILL.md
+++ b/plugins/atlas/skills/uproot/SKILL.md
@@ -264,34 +264,6 @@ with uproot.recreate("hists.root") as f:
     f["h_mass"] = h  # uproot can write hist.Hist directly
 ```
 
-## Gotchas
-
-- **ATLAS energy/momentum values are in MeV**: divide by 1000 before GeV-scale
-  histograms or cuts.
-- **Systematic trees**: TopCPToolkit writes one TTree per systematic variation
-  (e.g. `reco_JES__1up`). You must loop over tree names explicitly — there is no
-  automatic loop.
-- **`ak.to_numpy` fails on None**: filter with `~ak.is_none()` or
-  `ak.fill_none(arr, 0.0)` first.
-- **`tree.arrays()` reads all events by default**: for files with millions of
-  events use `iterate` or `entry_start`/`entry_stop`.
-- **TTree writing is limited**: jagged-array TTrees are restricted to one level
-  of variable-length lists. For richer nested structures, write an RNTuple
-  instead using `file.mkrntuple(...)`.
-
-## Interop
-
-- **awkward**: `tree.arrays()` returns `ak.Array` by default; pass
-  `library="np"` for flat branches.
-- **vector**: `vector.register_awkward()` adds Momentum4D behavior to awkward
-  records named `{pt,eta,phi,mass}`.
-- **hist**: Fill `hist.Hist` objects from uproot arrays; uproot can also write
-  `hist.Hist` objects to ROOT files.
-- **coffea**: `uproot.dask()` produces dask-awkward arrays for coffea
-  NanoAOD-style processors.
-- **fsspec-xrootd**: Mount EOS or grid storage so that uproot `root://` paths
-  work transparently.
-
 ## Worked Example: Full NTuple → histogram pipeline
 
 ```python
@@ -336,6 +308,34 @@ fig.savefig("leading_jet_pt.pdf")
 | Remote file stalls            | XRootD not installed                                       | `pip install uproot[xrootd]` or `fsspec-xrootd`          |
 | `UnicodeDecodeError`          | ROOT string branch with non-UTF8 content                   | Use `branch.array(interpretation=uproot.AsStrings(...))` |
 | `None` values in awkward      | `ak.firsts` returns `None` for empty events                | Use `mask = ~ak.is_none(arr)` before numpy conversion    |
+
+## Gotchas
+
+- **ATLAS energy/momentum values are in MeV**: divide by 1000 before GeV-scale
+  histograms or cuts.
+- **Systematic trees**: TopCPToolkit writes one TTree per systematic variation
+  (e.g. `reco_JES__1up`). You must loop over tree names explicitly — there is no
+  automatic loop.
+- **`ak.to_numpy` fails on None**: filter with `~ak.is_none()` or
+  `ak.fill_none(arr, 0.0)` first.
+- **`tree.arrays()` reads all events by default**: for files with millions of
+  events use `iterate` or `entry_start`/`entry_stop`.
+- **TTree writing is limited**: jagged-array TTrees are restricted to one level
+  of variable-length lists. For richer nested structures, write an RNTuple
+  instead using `file.mkrntuple(...)`.
+
+## Interop
+
+- **awkward**: `tree.arrays()` returns `ak.Array` by default; pass
+  `library="np"` for flat branches.
+- **vector**: `vector.register_awkward()` adds Momentum4D behavior to awkward
+  records named `{pt,eta,phi,mass}`.
+- **hist**: Fill `hist.Hist` objects from uproot arrays; uproot can also write
+  `hist.Hist` objects to ROOT files.
+- **coffea**: `uproot.dask()` produces dask-awkward arrays for coffea
+  NanoAOD-style processors.
+- **fsspec-xrootd**: Mount EOS or grid storage so that uproot `root://` paths
+  work transparently.
 
 ## Docs
 

--- a/plugins/atlas/skills/workspacecombiner/SKILL.md
+++ b/plugins/atlas/skills/workspacecombiner/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: workspacecombiner
+description: >-
+  Use when combining multiple RooFit workspaces with workspaceCombiner, editing
+  workspace parameterization with the manager edit command, printing or
+  splitting workspace categories, regulating a workspace, or preparing NP
+  renaming maps for ATLAS Higgs combination workflows.
+---
+
+# workspaceCombiner
+
+## Overview
+
+workspaceCombiner is an XML-driven tool for combining, editing, and debugging
+RooFit workspaces. Widely used in ATLAS and LHC combination efforts since the
+Higgs boson discovery, it provides four main operations:
+
+| Operation | Flag | Description |
+|---|---|---|
+| `combine` | `-w combine` | Combine multiple input workspaces into one |
+| `edit` | `-w edit` | Modify PDFs, NPs, POIs in an existing workspace |
+| `split`/`print` | `-w split`/`-w print` | Print workspace contents; extract a subset of categories |
+| `regulate` | `-w regulate` | Rebuild workspace PDFs with standardized structure |
+
+For statistical tests on a combined workspace, use
+[quickFit](https://gitlab.cern.ch/atlas_higgs_combination/software/quickFit).
+
+workspaceCombiner is included in the StatAnalysis release (available after
+`asetup StatAnalysis,0.7,latest`).
+
+Repository: https://gitlab.cern.ch/atlas_higgs_combination/software/workspaceCombiner/
+
+## Prerequisites for Input Workspaces
+
+Input workspaces must satisfy the following requirements:
+
+- **Fit model**: Use
+  [`RooSimultaneous`](https://root.cern.ch/doc/master/classRooSimultaneous.html)
+  even for single-category analyses.
+- **Data**: Use
+  [`RooDataSet`](https://root.cern.ch/doc/master/classRooDataSet.html),
+  categorized with the same `RooCategory` as the fit model.
+- **ModelConfig**: Provide a
+  [`RooStats::ModelConfig`](https://root.cern.ch/doc/master/classRooStats_1_1ModelConfig.html)
+  that correctly identifies observables, POIs, NPs, and global observables.
+- **Constraint PDFs**: Implement as normal (Gaussian, unit sigma, zero mean)
+  PDFs where possible; multiply them to the S+B PDF.
+- **Observable uniqueness**: Each observable must have a unique name across
+  the entire combination: `(observable)_(category)_(analysis)` convention
+  recommended.
+- **RooFormulaVar**: Use indexed syntax (`@0+@1`) not variable names; renaming
+  breaks name-based formulas.
+
+## Workspace Printing and Splitting
+
+```bash
+# Print workspace summary (categories, POIs, datasets)
+manager -w print -f ws.root --wsName combWS --dataName obsData
+
+# Extract categories 1, 3, 4, 5 into a new workspace
+manager -w split -f ws.root --wsName combWS --dataName obsData \
+  -i 1,3-5 -p split.root
+
+# Keep all categories (split with all)
+manager -w split -f ws.root --wsName combWS --dataName obsData -i all
+
+# Regulate: rebuild all category PDFs, strip unused constraint terms
+manager -w regulate -f ws.root --wsName combWS --dataName obsData
+```
+
+Split output always uses `combWS`/`ModelConfig`/`combData` as fixed names.
+Add `--rebuildPdf 1` to rebuild per-category PDFs. Add `--rebin N` to convert
+unbinned datasets to binned with N bins.
+
+## Workspace Editing
+
+Editing modifies parameterization of an existing workspace via an XML card:
+
+```bash
+manager -w edit -x modify.xml
+```
+
+### Edit card structure (Organization.dtd)
+
+```xml
+<!DOCTYPE Organization SYSTEM 'Organization.dtd'>
+<Organization InFile="input.root" OutFile="output.root"
+  ModelName="myModel"
+  POINames="mu,mu_ttH"
+  WorkspaceName="combWS"
+  ModelConfigName="ModelConfig"
+  DataName="combData">
+
+  <!-- Create new RooFit objects (RooWorkspace::factory syntax) -->
+  <Item Name="zero[0]"/>
+  <Item Name="RooGaussian::myConstr(myNP,myNP_In,1)"
+    Type="constraint" NP="myNP" GO="myNP_In"/>
+
+  <!-- Replace old objects with new ones -->
+  <Map Name="EDIT::NEWPDF(OLDPDF,
+    old_param=new_param,
+    old_NP=zero
+  )"/>
+
+  <!-- Optional: fit and/or create Asimov after editing -->
+  <Asimov Name="ucmles" Setup="mu=1_0_5"
+    Action="fit:savesnapshot" SnapshotAll="ucmles"/>
+</Organization>
+```
+
+`Organization.dtd` must be present in the same folder as the XML card.
+
+### Asimov action keywords
+
+| Keyword | Meaning |
+|---|---|
+| `fit` | Perform maximum likelihood fit |
+| `genasimov` | Generate Asimov dataset (once per action list) |
+| `savesnapshot` | Save snapshot (once per action list) |
+| `matchglob` | Match global observables to NP values; always pair with `reset` |
+| `reset` | Reset parameters to state before current action list |
+| `raw` | Reset to state before any actions |
+| `fixsyst` | Fix all constrained NPs |
+| `fixall` | Fix all NPs |
+| `float` | Float NPs fixed by `fixsyst` or `Setup` |
+| `<snapshot name>` | Load a named snapshot |
+
+Parameter `Setup` syntax: `param=value` to fix; `param=start_low_high` to float.
+
+## Workspace Combination
+
+Combines multiple input workspaces. Requires `Combination.dtd` in the same
+folder as XML cards.
+
+```bash
+manager -w combine -x combine.xml
+```
+
+### Combination card structure (Combination.dtd)
+
+```xml
+<!DOCTYPE Combination SYSTEM 'Combination.dtd'>
+<Combination WorkspaceName="combWS"
+  ModelConfigName="ModelConfig"
+  DataName="combData"
+  OutputFile="combined.root">
+
+  <!-- Combined POI list: value = fixed; start~lo~hi = floating -->
+  <POIList Combined="mu[1~0~5],mu_ttH[1]"/>
+
+  <!-- Optional fit / Asimov actions -->
+  <Asimov Name="ucmles" Setup="mu=1_0_5"
+    Action="fit:savesnapshot" SnapshotAll="ucmles"/>
+
+  <!-- One Channel block per input workspace -->
+  <Channel Name="channel_HZZ"
+    InputFile="reparam/WS-HZZ.root"
+    WorkspaceName="combined"
+    ModelConfigName="ModelConfig"
+    DataName="obsData">
+    <!-- Input POI list must match Combined POIList one-to-one; use "dummy" for missing POIs -->
+    <POIList Input="mu,mu_ttH,dummy,dummy"/>
+    <!-- NP renaming map for correlations -->
+    <RenameMap InputFile="syst_map/channel_HZZ.xml"/>
+  </Channel>
+
+  <Channel Name="channel_Hyy" ...>
+    ...
+  </Channel>
+</Combination>
+```
+
+Add tag `_binned` to the channel name (e.g. `channel_HZZ_binned`) to enable
+binned fit acceleration for HistFactory workspaces.
+
+Set `SimplifiedImport="true"` on a channel if all objects already have unique
+names — this skips renaming and is faster for large workspaces.
+
+## NP Renaming Maps
+
+The renaming map correlates NPs across input channels. NPs with the same
+`NewName` become correlated in the combination.
+
+```xml
+<!-- Gaussian-constrained NP -->
+<Syst OldName="lumi_pdf(lumi_NP, lumi_In)" NewName="ATLAS_LUMI_RUN2_CORR"/>
+
+<!-- Unconstrained (free) NP -->
+<Syst OldName="bkg_slope" NewName="bkg_slope_channel_yy"/>
+
+<!-- HistFactory gamma NPs (bin-by-bin stat) — never correlate across channels -->
+<Syst OldName="gamma_stat_SR_bin_0" NewName="gamma_stat_SR_bin_0"/>
+```
+
+NPs not listed in the map are renamed with the channel name as postfix. NPs
+listed but absent in the workspace are silently skipped.
+
+## Gotchas
+
+- **`Combination.dtd` / `Organization.dtd`**: must be in the same folder as
+  the XML card, not just the working directory.
+- **One-to-one POI list**: the `Input` POI list in each `Channel` must have
+  the same length as the `Combined` list; use `dummy` as placeholder.
+- **Cross-channel NP correlation**: achieved only through matching `NewName` in
+  renaming maps; never by identical `OldName`.
+- **Custom RooFit classes**: workspaces using classes outside vanilla ROOT
+  require those classes compiled into `RooFitExtensions` or added manually to
+  the workspaceCombiner source (`inc/` + `src/` + `LinkDef.h`).
+- **No intra-channel NP merging**: to correlate two NPs within the same input
+  channel, edit the workspace first before combining.
+
+## Interop
+
+- **quickFit**: recommended fitting tool for combined workspaces.
+- **xmlAnaWSBuilder**: produces single-channel analytic workspaces that are
+  valid workspaceCombiner inputs.
+- **StatAnalysis**: workspaceCombiner is available after
+  `asetup StatAnalysis,0.7,latest`.
+
+## Support
+
+Contact: workspaceCombiner-user@cern.ch
+
+## Docs
+
+https://gitlab.cern.ch/atlas_higgs_combination/software/workspaceCombiner/

--- a/plugins/atlas/skills/workspacecombiner/SKILL.md
+++ b/plugins/atlas/skills/workspacecombiner/SKILL.md
@@ -31,9 +31,24 @@ workspaceCombiner is included in the StatAnalysis release (available after
 Repository:
 https://gitlab.cern.ch/atlas_higgs_combination/software/workspaceCombiner/
 
-## Prerequisites for Input Workspaces
+## When to Use
 
-Input workspaces must satisfy the following requirements:
+- Combining multiple single-channel workspaces into a joint likelihood for an
+  ATLAS combination (Higgs coupling, cross-section measurement, etc.)
+- Editing an existing workspace to reparameterize POIs, rename or remove NPs, or
+  fix systematic sign conventions without remaking it from scratch
+- Printing a workspace summary (categories, POIs, datasets) or splitting a
+  subset of categories out for debugging
+- Regulating a workspace to standardize PDF structure or strip unused constraint
+  terms before passing it to downstream fitting tools
+- Preparing NP renaming maps to correlate or decorrelate systematics across
+  input channels
+
+## Key Concepts
+
+### Prerequisites for Input Workspaces
+
+Input workspaces must satisfy the following requirements before combination:
 
 - **Fit model**: Use
   [`RooSimultaneous`](https://root.cern.ch/doc/master/classRooSimultaneous.html)
@@ -50,9 +65,48 @@ Input workspaces must satisfy the following requirements:
   entire combination: `(observable)_(category)_(analysis)` convention
   recommended.
 - **RooFormulaVar**: Use indexed syntax (`@0+@1`) not variable names; renaming
-  breaks name-based formulas.
+  during combination breaks name-based formulas.
 
-## Workspace Printing and Splitting
+### NP Types
+
+| NP type              | Renaming map syntax        | Notes                           |
+| -------------------- | -------------------------- | ------------------------------- |
+| Gaussian-constrained | `OldName="pdf(NP, GO)"`    | Unit-sigma normal constraint    |
+| Unconstrained (free) | `OldName="np_name"`        | Background shape parameters     |
+| MC-stat (`gamma_*`)  | `OldName="gamma_stat_..."` | Never correlate across channels |
+
+### DTD Files
+
+Two DTD files are required alongside XML cards:
+
+- `Combination.dtd` — for `combine` operations
+- `Organization.dtd` — for `edit` operations
+
+Copy or symlink (`ln -s`) the relevant DTD into every directory containing XML
+cards.
+
+### Asimov Action Keywords
+
+Shared by both `combine` and `edit` XML cards (colon-separated in `Action`):
+
+| Keyword           | Meaning                                                         |
+| ----------------- | --------------------------------------------------------------- |
+| `fit`             | Maximum likelihood fit                                          |
+| `genasimov`       | Generate Asimov dataset (once per action list)                  |
+| `savesnapshot`    | Save parameter snapshot (once per action list)                  |
+| `matchglob`       | Match global observables to NP values; always pair with `reset` |
+| `reset`           | Reset parameters to state before current action list            |
+| `raw`             | Reset to state before any actions                               |
+| `fixsyst`         | Fix all constrained NPs                                         |
+| `fixall`          | Fix all NPs                                                     |
+| `float`           | Float NPs fixed by `fixsyst` or `Setup`                         |
+| `<snapshot name>` | Load a named snapshot                                           |
+
+Parameter `Setup` syntax: `param=value` to fix; `param=start_low_high` to float.
+
+## Canonical Patterns
+
+### Printing and Splitting a Workspace
 
 ```bash
 # Print workspace summary (categories, POIs, datasets)
@@ -73,15 +127,13 @@ Split output always uses `combWS`/`ModelConfig`/`combData` as fixed names. Add
 `--rebuildPdf 1` to rebuild per-category PDFs. Add `--rebin N` to convert
 unbinned datasets to binned with N bins.
 
-## Workspace Editing
+### Editing a Workspace
 
 Editing modifies parameterization of an existing workspace via an XML card:
 
 ```bash
 manager -w edit -x modify.xml
 ```
-
-### Edit card structure (Organization.dtd)
 
 ```xml
 <!DOCTYPE Organization SYSTEM 'Organization.dtd'>
@@ -109,35 +161,11 @@ manager -w edit -x modify.xml
 </Organization>
 ```
 
-`Organization.dtd` must be present in the same folder as the XML card.
-
-### Asimov action keywords
-
-| Keyword           | Meaning                                                         |
-| ----------------- | --------------------------------------------------------------- |
-| `fit`             | Perform maximum likelihood fit                                  |
-| `genasimov`       | Generate Asimov dataset (once per action list)                  |
-| `savesnapshot`    | Save snapshot (once per action list)                            |
-| `matchglob`       | Match global observables to NP values; always pair with `reset` |
-| `reset`           | Reset parameters to state before current action list            |
-| `raw`             | Reset to state before any actions                               |
-| `fixsyst`         | Fix all constrained NPs                                         |
-| `fixall`          | Fix all NPs                                                     |
-| `float`           | Float NPs fixed by `fixsyst` or `Setup`                         |
-| `<snapshot name>` | Load a named snapshot                                           |
-
-Parameter `Setup` syntax: `param=value` to fix; `param=start_low_high` to float.
-
-## Workspace Combination
-
-Combines multiple input workspaces. Requires `Combination.dtd` in the same
-folder as XML cards.
+### Combining Workspaces
 
 ```bash
 manager -w combine -x combine.xml
 ```
-
-### Combination card structure (Combination.dtd)
 
 ```xml
 <!DOCTYPE Combination SYSTEM 'Combination.dtd'>
@@ -159,25 +187,18 @@ manager -w combine -x combine.xml
     WorkspaceName="combined"
     ModelConfigName="ModelConfig"
     DataName="obsData">
-    <!-- Input POI list must match Combined POIList one-to-one; use "dummy" for missing POIs -->
+    <!-- Input POI list must be one-to-one with Combined list; use "dummy" for missing POIs -->
     <POIList Input="mu,mu_ttH,dummy,dummy"/>
-    <!-- NP renaming map for correlations -->
     <RenameMap InputFile="syst_map/channel_HZZ.xml"/>
-  </Channel>
-
-  <Channel Name="channel_Hyy" ...>
-    ...
   </Channel>
 </Combination>
 ```
 
-Add tag `_binned` to the channel name (e.g. `channel_HZZ_binned`) to enable
-binned fit acceleration for HistFactory workspaces.
+Add `_binned` to the channel name (e.g. `channel_HZZ_binned`) to enable binned
+fit acceleration for HistFactory workspaces. Set `SimplifiedImport="true"` on a
+channel to skip renaming when all objects already have unique names.
 
-Set `SimplifiedImport="true"` on a channel if all objects already have unique
-names — this skips renaming and is faster for large workspaces.
-
-## NP Renaming Maps
+### NP Renaming Maps
 
 The renaming map correlates NPs across input channels. NPs with the same
 `NewName` become correlated in the combination.
@@ -209,6 +230,9 @@ listed but absent in the workspace are silently skipped.
   the workspaceCombiner source (`inc/` + `src/` + `LinkDef.h`).
 - **No intra-channel NP merging**: to correlate two NPs within the same input
   channel, edit the workspace first before combining.
+- **All ATLAS energy/momentum values are in MeV**: workspace observables and
+  histogram axes from ATLAS reconstruction use MeV (1 GeV = 1000 MeV); convert
+  explicitly when comparing with external inputs.
 
 ## Interop
 
@@ -217,8 +241,6 @@ listed but absent in the workspace are silently skipped.
   valid workspaceCombiner inputs.
 - **StatAnalysis**: workspaceCombiner is available after
   `asetup StatAnalysis,0.7,latest`.
-
-## Support
 
 Contact: workspaceCombiner-user@cern.ch
 

--- a/plugins/atlas/skills/workspacecombiner/SKILL.md
+++ b/plugins/atlas/skills/workspacecombiner/SKILL.md
@@ -15,12 +15,12 @@ workspaceCombiner is an XML-driven tool for combining, editing, and debugging
 RooFit workspaces. Widely used in ATLAS and LHC combination efforts since the
 Higgs boson discovery, it provides four main operations:
 
-| Operation | Flag | Description |
-|---|---|---|
-| `combine` | `-w combine` | Combine multiple input workspaces into one |
-| `edit` | `-w edit` | Modify PDFs, NPs, POIs in an existing workspace |
+| Operation       | Flag                  | Description                                              |
+| --------------- | --------------------- | -------------------------------------------------------- |
+| `combine`       | `-w combine`          | Combine multiple input workspaces into one               |
+| `edit`          | `-w edit`             | Modify PDFs, NPs, POIs in an existing workspace          |
 | `split`/`print` | `-w split`/`-w print` | Print workspace contents; extract a subset of categories |
-| `regulate` | `-w regulate` | Rebuild workspace PDFs with standardized structure |
+| `regulate`      | `-w regulate`         | Rebuild workspace PDFs with standardized structure       |
 
 For statistical tests on a combined workspace, use
 [quickFit](https://gitlab.cern.ch/atlas_higgs_combination/software/quickFit).
@@ -28,7 +28,8 @@ For statistical tests on a combined workspace, use
 workspaceCombiner is included in the StatAnalysis release (available after
 `asetup StatAnalysis,0.7,latest`).
 
-Repository: https://gitlab.cern.ch/atlas_higgs_combination/software/workspaceCombiner/
+Repository:
+https://gitlab.cern.ch/atlas_higgs_combination/software/workspaceCombiner/
 
 ## Prerequisites for Input Workspaces
 
@@ -45,8 +46,8 @@ Input workspaces must satisfy the following requirements:
   that correctly identifies observables, POIs, NPs, and global observables.
 - **Constraint PDFs**: Implement as normal (Gaussian, unit sigma, zero mean)
   PDFs where possible; multiply them to the S+B PDF.
-- **Observable uniqueness**: Each observable must have a unique name across
-  the entire combination: `(observable)_(category)_(analysis)` convention
+- **Observable uniqueness**: Each observable must have a unique name across the
+  entire combination: `(observable)_(category)_(analysis)` convention
   recommended.
 - **RooFormulaVar**: Use indexed syntax (`@0+@1`) not variable names; renaming
   breaks name-based formulas.
@@ -68,8 +69,8 @@ manager -w split -f ws.root --wsName combWS --dataName obsData -i all
 manager -w regulate -f ws.root --wsName combWS --dataName obsData
 ```
 
-Split output always uses `combWS`/`ModelConfig`/`combData` as fixed names.
-Add `--rebuildPdf 1` to rebuild per-category PDFs. Add `--rebin N` to convert
+Split output always uses `combWS`/`ModelConfig`/`combData` as fixed names. Add
+`--rebuildPdf 1` to rebuild per-category PDFs. Add `--rebin N` to convert
 unbinned datasets to binned with N bins.
 
 ## Workspace Editing
@@ -112,18 +113,18 @@ manager -w edit -x modify.xml
 
 ### Asimov action keywords
 
-| Keyword | Meaning |
-|---|---|
-| `fit` | Perform maximum likelihood fit |
-| `genasimov` | Generate Asimov dataset (once per action list) |
-| `savesnapshot` | Save snapshot (once per action list) |
-| `matchglob` | Match global observables to NP values; always pair with `reset` |
-| `reset` | Reset parameters to state before current action list |
-| `raw` | Reset to state before any actions |
-| `fixsyst` | Fix all constrained NPs |
-| `fixall` | Fix all NPs |
-| `float` | Float NPs fixed by `fixsyst` or `Setup` |
-| `<snapshot name>` | Load a named snapshot |
+| Keyword           | Meaning                                                         |
+| ----------------- | --------------------------------------------------------------- |
+| `fit`             | Perform maximum likelihood fit                                  |
+| `genasimov`       | Generate Asimov dataset (once per action list)                  |
+| `savesnapshot`    | Save snapshot (once per action list)                            |
+| `matchglob`       | Match global observables to NP values; always pair with `reset` |
+| `reset`           | Reset parameters to state before current action list            |
+| `raw`             | Reset to state before any actions                               |
+| `fixsyst`         | Fix all constrained NPs                                         |
+| `fixall`          | Fix all NPs                                                     |
+| `float`           | Float NPs fixed by `fixsyst` or `Setup`                         |
+| `<snapshot name>` | Load a named snapshot                                           |
 
 Parameter `Setup` syntax: `param=value` to fix; `param=start_low_high` to float.
 
@@ -197,10 +198,10 @@ listed but absent in the workspace are silently skipped.
 
 ## Gotchas
 
-- **`Combination.dtd` / `Organization.dtd`**: must be in the same folder as
-  the XML card, not just the working directory.
-- **One-to-one POI list**: the `Input` POI list in each `Channel` must have
-  the same length as the `Combined` list; use `dummy` as placeholder.
+- **`Combination.dtd` / `Organization.dtd`**: must be in the same folder as the
+  XML card, not just the working directory.
+- **One-to-one POI list**: the `Input` POI list in each `Channel` must have the
+  same length as the `Combined` list; use `dummy` as placeholder.
 - **Cross-channel NP correlation**: achieved only through matching `NewName` in
   renaming maps; never by identical `OldName`.
 - **Custom RooFit classes**: workspaces using classes outside vanilla ROOT

--- a/plugins/atlas/skills/xcache/SKILL.md
+++ b/plugins/atlas/skills/xcache/SKILL.md
@@ -29,10 +29,10 @@ speed.
 
 **Local vs remote proxy**: XCache exposes two proxy endpoints after starting:
 
-| Variable                     | Endpoint                                 | Use case                                     |
-| ---------------------------- | ---------------------------------------- | -------------------------------------------- |
-| `ALRB_XCACHE_PROXY`         | `root://localhost:59560//`               | Same machine as the cache                    |
-| `ALRB_XCACHE_PROXY_REMOTE`  | `root://atlasremote.triumf.ca:59560//`   | Other machines on the same local network     |
+| Variable                   | Endpoint                               | Use case                                 |
+| -------------------------- | -------------------------------------- | ---------------------------------------- |
+| `ALRB_XCACHE_PROXY`        | `root://localhost:59560//`             | Same machine as the cache                |
+| `ALRB_XCACHE_PROXY_REMOTE` | `root://atlasremote.triumf.ca:59560//` | Other machines on the same local network |
 
 **How it works**: Prepend the proxy variable to any `root://` URI. XCache
 intercepts the request, fetches blocks from the remote server, stores them on
@@ -154,8 +154,8 @@ the network.
 
 ## Interop
 
-- **setupATLAS**: `lsetup xcache` requires `setupATLAS` to be sourced first.
-  See the setupatlas skill.
+- **setupATLAS**: `lsetup xcache` requires `setupATLAS` to be sourced first. See
+  the setupatlas skill.
 - **fsspec-xrootd / uproot**: Prepend the xcache proxy to `root://` URIs passed
   to uproot for cached Python access. See the fsspec-xrootd skill.
 - **Rucio**: Use `rucio list-file-replicas` to obtain `root://` PFNs, then

--- a/plugins/atlas/skills/xcache/SKILL.md
+++ b/plugins/atlas/skills/xcache/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: xcache
+description: >-
+  Use when setting up a local XCache disk caching proxy for XRootD root://
+  protocol access: starting an xcache instance, caching remote ATLAS files on a
+  laptop or Tier-3 site, using ALRB_XCACHE_PROXY with ROOT or Rucio file
+  replicas, or troubleshooting VOMS proxy and cache directory issues.
+---
+
+# XCache
+
+## Overview
+
+XCache is a local disk caching proxy for remote file access via the XRootD
+`root://` protocol. It intercepts `root://` requests, caches the data on local
+disk, and serves subsequent reads from the cache. This is useful for laptops,
+desktops, and Tier-3 sites that repeatedly access the same remote files — the
+first access goes over the network, but subsequent accesses are local disk
+speed.
+
+## When to Use
+
+- Running an analysis that repeatedly reads the same remote ROOT files
+- Working on a laptop or desktop with limited bandwidth to WLCG storage
+- Setting up a shared cache on a Tier-3 site to reduce external network traffic
+- Accelerating iterative development where the same NTuples are read many times
+
+## Key Concepts
+
+**Local vs remote proxy**: XCache exposes two proxy endpoints after starting:
+
+| Variable                     | Endpoint                                 | Use case                                     |
+| ---------------------------- | ---------------------------------------- | -------------------------------------------- |
+| `ALRB_XCACHE_PROXY`         | `root://localhost:59560//`               | Same machine as the cache                    |
+| `ALRB_XCACHE_PROXY_REMOTE`  | `root://atlasremote.triumf.ca:59560//`   | Other machines on the same local network     |
+
+**How it works**: Prepend the proxy variable to any `root://` URI. XCache
+intercepts the request, fetches blocks from the remote server, stores them on
+local disk, and serves them. Repeated reads of the same blocks hit the local
+cache.
+
+**VOMS proxy required**: XCache authenticates to remote storage using a valid
+VOMS proxy. A long-lived proxy (96 hours) is recommended to avoid expiry during
+extended analysis sessions.
+
+## Canonical Patterns
+
+### Setup and start
+
+```bash
+setupATLAS
+lsetup xcache
+voms-proxy-init -voms atlas -valid 96:0
+xcache start -d /tmp/myCache
+```
+
+### Setup alongside a release
+
+```bash
+lsetup "asetup AthAnalysis,21.2.3" xcache
+voms-proxy-init -voms atlas -valid 96:0
+xcache start -d /tmp/myCache
+```
+
+### Access a remote file through the local cache
+
+```bash
+root [0] TFile::Open("${ALRB_XCACHE_PROXY}root://tbn18.nikhef.nl:1094//pnfs/nikhef.nl/data/atlas/path/to/file.root")
+```
+
+The first open fetches from the remote server and caches locally. Subsequent
+opens of the same file read from disk.
+
+### Access via the remote proxy (other machines on the network)
+
+```bash
+root [0] TFile::Open("${ALRB_XCACHE_PROXY_REMOTE}root://tbn18.nikhef.nl:1094//pnfs/nikhef.nl/data/atlas/path/to/file.root")
+```
+
+### Use with Rucio file replicas
+
+Generate cached URIs from Rucio replica output:
+
+```bash
+rucio list-file-replicas --rse SOME_RSE --protocol root --pfns scope:dataset \
+  | sed -e 's/^root/${ALRB_XCACHE_PROXY}root/'
+```
+
+### Use with uproot (Python)
+
+```python
+import os
+import uproot
+import fsspec_xrootd  # noqa: F401 — registers root:// scheme
+
+proxy = os.environ["ALRB_XCACHE_PROXY"]
+remote_uri = "root://eosatlas.cern.ch//eos/atlas/path/to/file.root"
+cached_uri = f"{proxy}{remote_uri}"
+
+with uproot.open(f"{cached_uri}:tree") as tree:
+    arrays = tree.arrays(["jet_pt", "met_met"])
+```
+
+### Stop the cache
+
+```bash
+xcache stop
+```
+
+### Check cache status
+
+```bash
+xcache status
+```
+
+### Automatic proxy renewal
+
+For long-running sessions, configure automatic proxy delegation:
+
+```bash
+# See the example script for myproxy-based renewal
+cat $ATLAS_LOCAL_ROOT_BASE/user/myproxydelegate-example.sh
+```
+
+### Use with xrdcp for bulk downloads
+
+```bash
+# Download through the cache with xrdcp
+xrdcp ${ALRB_XCACHE_PROXY}root://remote-server:1094//path/to/file.root local.root
+```
+
+Subsequent xrdcp calls for the same file read from the local cache instead of
+the network.
+
+## Gotchas
+
+- **VOMS proxy required**: XCache cannot authenticate to remote storage without
+  a valid proxy. Use `voms-proxy-info --all` to check, and
+  `voms-proxy-init -voms atlas -valid 96:0` to renew.
+- **Cache directory can grow large**: Monitor disk usage in the cache directory.
+  XCache does not automatically evict old files — manage the directory manually
+  or set up a cron job.
+- **Port conflicts**: The default port is 59560. If another xcache instance or
+  service uses that port, `xcache start` will fail. Check with
+  `netstat -tlnp | grep 59560`.
+- **localhost vs remote endpoint**: `ALRB_XCACHE_PROXY` uses `localhost` and
+  only works on the machine running xcache. Use `ALRB_XCACHE_PROXY_REMOTE` for
+  access from other machines on the same network.
+- **Environment variables disappear in new shells**: The `ALRB_XCACHE_PROXY`
+  variables are set by `xcache start` in the current shell only. Re-export them
+  or re-run `lsetup xcache` in new terminal sessions.
+- **ATLAS energy/momentum values are in MeV**: Fields read from ATLAS NTuples
+  through xcache are still in MeV — divide by 1000 for GeV-scale comparisons.
+
+## Interop
+
+- **setupATLAS**: `lsetup xcache` requires `setupATLAS` to be sourced first.
+  See the setupatlas skill.
+- **fsspec-xrootd / uproot**: Prepend the xcache proxy to `root://` URIs passed
+  to uproot for cached Python access. See the fsspec-xrootd skill.
+- **Rucio**: Use `rucio list-file-replicas` to obtain `root://` PFNs, then
+  prepend the xcache proxy for cached access.
+- **asetup**: XCache can be set up alongside a release —
+  `lsetup "asetup ..." xcache` configures both in one command.
+
+## Docs
+
+- https://twiki.atlas-canada.ca/bin/view/AtlasCanada/Xcache
+- https://gitlab.cern.ch/atlas-tier3sw/xcache

--- a/plugins/atlas/skills/xmlanawsbuilder/SKILL.md
+++ b/plugins/atlas/skills/xmlanawsbuilder/SKILL.md
@@ -13,8 +13,8 @@ description: >-
 
 ## Overview
 
-xmlAnaWSBuilder constructs RooFit workspaces for statistical analyses using
-XML configuration cards. It specializes in:
+xmlAnaWSBuilder constructs RooFit workspaces for statistical analyses using XML
+configuration cards. It specializes in:
 
 - **1D analytic models** (e.g. H→γγ signal as double-sided Crystal Ball,
   background as polynomial or power-law)
@@ -24,11 +24,11 @@ XML configuration cards. It specializes in:
 The produced workspace follows the standard `RooSimultaneous` + `ModelConfig`
 convention and can be used directly with
 [workspaceCombiner](https://gitlab.cern.ch/atlas_higgs_combination/software/workspaceCombiner)
-and [quickFit](https://gitlab.cern.ch/atlas_higgs_combination/software/quickFit).
+and
+[quickFit](https://gitlab.cern.ch/atlas_higgs_combination/software/quickFit).
 
 xmlAnaWSBuilder is included in the StatAnalysis release. It can also be built
-standalone from:
-https://gitlab.cern.ch/atlas-hgam-sw/xmlAnaWSBuilder
+standalone from: https://gitlab.cern.ch/atlas-hgam-sw/xmlAnaWSBuilder
 
 ## Running XMLReader
 
@@ -41,15 +41,15 @@ XMLReader -x config/top.xml -b 1 -s 0        # binned fit, Minuit2 strategy 0
 XMLReader -x config/top.xml -v               # verbose debug output
 ```
 
-| Option | Description |
-|---|---|
-| `-x` / `--xml` | Top-level XML card path (required) |
-| `-v` / `--verbose` | Print debug info |
-| `-m` / `--minimizerAlgo` | `Minuit2` (default) or `Minuit` |
-| `-s` / `--minimizerStrategy` | 0, 1 (default), or 2 |
-| `-t` / `--minimizerTolerance` | Default 1e-3 |
-| `-b` / `--binned` | Fit to binned (pseudo-binned) dataset |
-| `-o` / `--plotOption` | Plot options (e.g. `logy`, `rebin10`) |
+| Option                        | Description                           |
+| ----------------------------- | ------------------------------------- |
+| `-x` / `--xml`                | Top-level XML card path (required)    |
+| `-v` / `--verbose`            | Print debug info                      |
+| `-m` / `--minimizerAlgo`      | `Minuit2` (default) or `Minuit`       |
+| `-s` / `--minimizerStrategy`  | 0, 1 (default), or 2                  |
+| `-t` / `--minimizerTolerance` | Default 1e-3                          |
+| `-b` / `--binned`             | Fit to binned (pseudo-binned) dataset |
+| `-o` / `--plotOption`         | Plot options (e.g. `logy`, `rebin10`) |
 
 ## Three-Level XML Structure
 
@@ -83,23 +83,23 @@ top-level card (.xml)
 </Combination>
 ```
 
-For blinded analysis set `Blind="true"` and add `BlindRange` to each `Data`
-node (see [Blinded Analysis](#blinded-analysis)).
+For blinded analysis set `Blind="true"` and add `BlindRange` to each `Data` node
+(see [Blinded Analysis](#blinded-analysis)).
 
 ### Asimov action keywords
 
-| Keyword | Meaning |
-|---|---|
-| `fit` | Maximum likelihood fit |
-| `genasimov` | Generate Asimov dataset (once per line) |
-| `savesnapshot` | Save parameter snapshot (once per line) |
-| `matchglob` | Match global observables to NP values; always pair with `reset` |
-| `reset` | Reset to state before current action list |
-| `raw` | Reset to state before any actions |
-| `fixsyst` | Fix all constrained NPs |
-| `fixall` | Fix all NPs |
-| `float` | Float NPs fixed by `fixsyst` or `Setup` |
-| `<snapshot name>` | Load a saved snapshot |
+| Keyword           | Meaning                                                         |
+| ----------------- | --------------------------------------------------------------- |
+| `fit`             | Maximum likelihood fit                                          |
+| `genasimov`       | Generate Asimov dataset (once per line)                         |
+| `savesnapshot`    | Save parameter snapshot (once per line)                         |
+| `matchglob`       | Match global observables to NP values; always pair with `reset` |
+| `reset`           | Reset to state before current action list                       |
+| `raw`             | Reset to state before any actions                               |
+| `fixsyst`         | Fix all constrained NPs                                         |
+| `fixall`          | Fix all NPs                                                     |
+| `float`           | Float NPs fixed by `fixsyst` or `Setup`                         |
+| `<snapshot name>` | Load a saved snapshot                                           |
 
 ## Category-Level Card
 
@@ -135,55 +135,55 @@ node (see [Blinded Analysis](#blinded-analysis)).
 
 ### Data node attributes
 
-| Attribute | Description |
-|---|---|
-| `InputFile` | Data file path (text, ROOT ntuple, or histogram) |
-| `FileType` | `ascii` (default), `root`, or `histogram` |
-| `TreeName` | TTree name (ROOT ntuple only) |
-| `VarName` | Branch name (ROOT ntuple only) |
-| `HistName` | Histogram name (histogram mode only) |
-| `Observable` | `name:[lo,hi]` — name and range of observable |
-| `Binning` | Number of bins for Asimov and pseudo-binned dataset |
+| Attribute     | Description                                           |
+| ------------- | ----------------------------------------------------- |
+| `InputFile`   | Data file path (text, ROOT ntuple, or histogram)      |
+| `FileType`    | `ascii` (default), `root`, or `histogram`             |
+| `TreeName`    | TTree name (ROOT ntuple only)                         |
+| `VarName`     | Branch name (ROOT ntuple only)                        |
+| `HistName`    | Histogram name (histogram mode only)                  |
+| `Observable`  | `name:[lo,hi]` — name and range of observable         |
+| `Binning`     | Number of bins for Asimov and pseudo-binned dataset   |
 | `InjectGhost` | `true`: inject weight-1e-9 ghost events per empty bin |
-| `NumData` | Number of observed events (counting experiments only) |
-| `BlindRange` | Range to veto, e.g. `120,130` |
+| `NumData`     | Number of observed events (counting experiments only) |
+| `BlindRange`  | Range to veto, e.g. `120,130`                         |
 
 Choose fine enough `Binning` — typically 10× smaller than detector resolution.
 The pseudo-binned dataset introduces bias if bins are too coarse.
 
 ### Systematic node attributes
 
-| Attribute | Description |
-|---|---|
-| `Name` | Nuisance parameter name (same name = correlated across categories) |
-| `Constr` | Constraint type: `gaus`, `logn`, `asym`, `dfd` |
-| `CentralValue` | Nominal response value (usually `1`; use `0` for additive) |
-| `Mag` | Uncertainty magnitude; for `asym`: `upper,lower` |
-| `WhereTo` | `yield` (auto-applied) or `shape` (user must place `response::`) |
-| `Process` | Group name for routing to specific samples via `ImportSyst` |
+| Attribute      | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
+| `Name`         | Nuisance parameter name (same name = correlated across categories) |
+| `Constr`       | Constraint type: `gaus`, `logn`, `asym`, `dfd`                     |
+| `CentralValue` | Nominal response value (usually `1`; use `0` for additive)         |
+| `Mag`          | Uncertainty magnitude; for `asym`: `upper,lower`                   |
+| `WhereTo`      | `yield` (auto-applied) or `shape` (user must place `response::`)   |
+| `Process`      | Group name for routing to specific samples via `ImportSyst`        |
 
 **Constraint types and response functions:**
 
-| Type | Response function |
-|---|---|
-| `gaus` | `CentralValue + NP × Mag` |
-| `logn` | `(1 + Mag/CentralValue)^NP` |
+| Type   | Response function                                              |
+| ------ | -------------------------------------------------------------- |
+| `gaus` | `CentralValue + NP × Mag`                                      |
+| `logn` | `(1 + Mag/CentralValue)^NP`                                    |
 | `asym` | Polynomial interp within ±1σ, log-normal extrapolation outside |
-| `dfd` | Double-Fermi-Dirac box (for ill-defined uncertainties) |
+| `dfd`  | Double-Fermi-Dirac box (for ill-defined uncertainties)         |
 
 Signs in `Mag` matter — always follow the sign convention of the upstream tool.
 For `asym`, only the sign of the upper uncertainty is used.
 
 ### Sample node attributes
 
-| Attribute | Description |
-|---|---|
-| `Name` | Process name (unique within category) |
-| `InputFile` | Path to pdf-level XML card |
-| `ImportSyst` | Comma-separated common systematic groups; `:common:` = all ungrouped; `:self:` = none |
-| `MultiplyLumi` | Whether to multiply `Lumi` to yield |
-| `SharePdf` | All processes with the same value share a single PDF |
-| `Norm`, `XSection`, `BR`, etc. | Pre-defined constant scale factors on yield |
+| Attribute                      | Description                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| `Name`                         | Process name (unique within category)                                                 |
+| `InputFile`                    | Path to pdf-level XML card                                                            |
+| `ImportSyst`                   | Comma-separated common systematic groups; `:common:` = all ungrouped; `:self:` = none |
+| `MultiplyLumi`                 | Whether to multiply `Lumi` to yield                                                   |
+| `SharePdf`                     | All processes with the same value share a single PDF                                  |
+| `Norm`, `XSection`, `BR`, etc. | Pre-defined constant scale factors on yield                                           |
 
 ### NormFactor and ShapeFactor
 
@@ -217,16 +217,16 @@ Keep observable name consistent with HistFactory when importing external PDFs.
 
 ## XML Keywords
 
-| Keyword | Meaning |
-|---|---|
-| `response::<NP>` | Response function for NP (in same domain) |
-| `:category:` | Replaced by current category name |
-| `:observable:` | Observable name of current category |
-| `:process:` | Name of current Sample |
-| `:common:` | All ungrouped common systematics |
-| `:self:` | Only process-specific systematics; suppresses `:common:` |
-| `:lt:` `:le:` `:gt:` `:ge:` | `<` `<=` `>` `>=` (XML-safe math symbols) |
-| `:and:` `:or:` | Logic operators for ntuple cuts |
+| Keyword                     | Meaning                                                  |
+| --------------------------- | -------------------------------------------------------- |
+| `response::<NP>`            | Response function for NP (in same domain)                |
+| `:category:`                | Replaced by current category name                        |
+| `:observable:`              | Observable name of current category                      |
+| `:process:`                 | Name of current Sample                                   |
+| `:common:`                  | All ungrouped common systematics                         |
+| `:self:`                    | Only process-specific systematics; suppresses `:common:` |
+| `:lt:` `:le:` `:gt:` `:ge:` | `<` `<=` `>` `>=` (XML-safe math symbols)                |
+| `:and:` `:or:`              | Logic operators for ntuple cuts                          |
 
 `RooFormulaVar` must use indexed syntax `@0, @1, ...` — never variable names
 (renaming during workspace creation breaks name-based references).
@@ -265,16 +265,15 @@ Remove `SBLo` or `SBHi` if the blinded range touches the observable boundary.
 
 ## Gotchas
 
-- **`AnaWSBuilder.dtd` location**: must be in every folder containing XML
-  cards — copy or symlink (`ln -s`) from the xmlAnaWSBuilder repo `dtd/`
-  directory.
+- **`AnaWSBuilder.dtd` location**: must be in every folder containing XML cards
+  — copy or symlink (`ln -s`) from the xmlAnaWSBuilder repo `dtd/` directory.
 - **Fine binning is critical**: pseudo-binned and Asimov datasets are biased
   when bins are coarse; use ~10× finer than detector resolution.
 - **Indexed proxies in formulas**: `RooFormulaVar` must use `@0, @1, ...`
   because variables are renamed during workspace construction.
-- **`matchglob` + `reset`**: always call `reset` at the end of any action
-  list containing `matchglob`, otherwise global observable values are altered
-  in the final workspace.
+- **`matchglob` + `reset`**: always call `reset` at the end of any action list
+  containing `matchglob`, otherwise global observable values are altered in the
+  final workspace.
 - **ResponseFunction custom class**: all workspaces produced by xmlAnaWSBuilder
   contain the `ResponseFunction` class (available in `RooFitExtensions`);
   downstream tools must have `RooFitExtensions` on `LD_LIBRARY_PATH`.

--- a/plugins/atlas/skills/xmlanawsbuilder/SKILL.md
+++ b/plugins/atlas/skills/xmlanawsbuilder/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: xmlanawsbuilder
+description: >-
+  Use when building a RooFit workspace from XML cards with xmlAnaWSBuilder or
+  XMLReader, constructing analytic signal or background models for H→γγ or
+  similar ATLAS analyses, configuring systematic uncertainties in the XML
+  workspace builder, setting up counting experiments, implementing blinded
+  analysis ranges, or combining categories into a likelihood workspace for
+  downstream fitting with quickFit or workspaceCombiner.
+---
+
+# xmlAnaWSBuilder
+
+## Overview
+
+xmlAnaWSBuilder constructs RooFit workspaces for statistical analyses using
+XML configuration cards. It specializes in:
+
+- **1D analytic models** (e.g. H→γγ signal as double-sided Crystal Ball,
+  background as polynomial or power-law)
+- **Counting experiments** (no shape information)
+- **Multi-category likelihoods** combining signal and background processes
+
+The produced workspace follows the standard `RooSimultaneous` + `ModelConfig`
+convention and can be used directly with
+[workspaceCombiner](https://gitlab.cern.ch/atlas_higgs_combination/software/workspaceCombiner)
+and [quickFit](https://gitlab.cern.ch/atlas_higgs_combination/software/quickFit).
+
+xmlAnaWSBuilder is included in the StatAnalysis release. It can also be built
+standalone from:
+https://gitlab.cern.ch/atlas-hgam-sw/xmlAnaWSBuilder
+
+## Running XMLReader
+
+```bash
+XMLReader -x config/myanalysis/top.xml
+
+# With options
+XMLReader -x config/top.xml --plot rebin10
+XMLReader -x config/top.xml -b 1 -s 0        # binned fit, Minuit2 strategy 0
+XMLReader -x config/top.xml -v               # verbose debug output
+```
+
+| Option | Description |
+|---|---|
+| `-x` / `--xml` | Top-level XML card path (required) |
+| `-v` / `--verbose` | Print debug info |
+| `-m` / `--minimizerAlgo` | `Minuit2` (default) or `Minuit` |
+| `-s` / `--minimizerStrategy` | 0, 1 (default), or 2 |
+| `-t` / `--minimizerTolerance` | Default 1e-3 |
+| `-b` / `--binned` | Fit to binned (pseudo-binned) dataset |
+| `-o` / `--plotOption` | Plot options (e.g. `logy`, `rebin10`) |
+
+## Three-Level XML Structure
+
+```
+top-level card (.xml)
+  └── category-level cards (one per analysis category)
+        └── pdf-level cards (one per physics process per category)
+```
+
+`AnaWSBuilder.dtd` must be present alongside every XML card file.
+
+## Top-Level Card
+
+```xml
+<!DOCTYPE Combination SYSTEM 'AnaWSBuilder.dtd'>
+<Combination WorkspaceName="combWS" ModelConfigName="ModelConfig"
+  DataName="combData" OutputFile="workspace/output.root" Blind="false">
+
+  <Input>config/category_A.xml</Input>
+  <Input>config/category_B.xml</Input>
+
+  <POI>mu,mu_ttH</POI>
+
+  <!-- Fit and/or Asimov generation actions -->
+  <Asimov Name="asimovData_0" Setup="mu=0"
+    Action="fixsyst:fit:genasimov:float:savesnapshot"
+    SnapshotNuis="nominalNuis" SnapshotGlob="nominalGlob"/>
+  <Asimov Name="asimovData_1" Setup="mu=1,mu_ttH=1"
+    Action="fit:matchglob:genasimov:savesnapshot:reset"
+    SnapshotNuis="conditionalNuis_1" SnapshotGlob="conditionalGlob_1"/>
+</Combination>
+```
+
+For blinded analysis set `Blind="true"` and add `BlindRange` to each `Data`
+node (see [Blinded Analysis](#blinded-analysis)).
+
+### Asimov action keywords
+
+| Keyword | Meaning |
+|---|---|
+| `fit` | Maximum likelihood fit |
+| `genasimov` | Generate Asimov dataset (once per line) |
+| `savesnapshot` | Save parameter snapshot (once per line) |
+| `matchglob` | Match global observables to NP values; always pair with `reset` |
+| `reset` | Reset to state before current action list |
+| `raw` | Reset to state before any actions |
+| `fixsyst` | Fix all constrained NPs |
+| `fixall` | Fix all NPs |
+| `float` | Float NPs fixed by `fixsyst` or `Setup` |
+| `<snapshot name>` | Load a saved snapshot |
+
+## Category-Level Card
+
+```xml
+<!DOCTYPE Channel SYSTEM 'AnaWSBuilder.dtd'>
+<Channel Name="ttH_c27" Type="shape" Lumi="139">
+
+  <!-- Dataset from text file -->
+  <Data InputFile="data/mass_points.txt"
+    Observable="atlas_invMass_:category:[105,160]"
+    Binning="220" InjectGhost="true" BlindRange="120,130"/>
+
+  <!-- Common yield systematics (applied to processes via ImportSyst) -->
+  <Systematic Name="ATLAS_lumi_run2" Constr="logn"
+    CentralValue="1" Mag="0.017" WhereTo="yield"/>
+
+  <!-- Common items (variables, functions) -->
+  <Item Name="prod::resp_RES(response::ATLAS_EG_RESOLUTION_ALL)"/>
+
+  <!-- Physics process -->
+  <Sample Name="signal" InputFile="config/model/signal_:category:.xml"
+    ImportSyst=":common:" MultiplyLumi="true" SharePdf="commonSig">
+    <NormFactor Name="yield_sig[10,0,1000]"/>
+    <NormFactor Name="mu[1,0,5]"/>
+  </Sample>
+
+  <Sample Name="background" InputFile="config/model/bkg_:category:.xml"
+    ImportSyst=":self:" MultiplyLumi="false">
+    <NormFactor Name="nbkg_:category:[100,0,100000]"/>
+  </Sample>
+</Channel>
+```
+
+### Data node attributes
+
+| Attribute | Description |
+|---|---|
+| `InputFile` | Data file path (text, ROOT ntuple, or histogram) |
+| `FileType` | `ascii` (default), `root`, or `histogram` |
+| `TreeName` | TTree name (ROOT ntuple only) |
+| `VarName` | Branch name (ROOT ntuple only) |
+| `HistName` | Histogram name (histogram mode only) |
+| `Observable` | `name:[lo,hi]` — name and range of observable |
+| `Binning` | Number of bins for Asimov and pseudo-binned dataset |
+| `InjectGhost` | `true`: inject weight-1e-9 ghost events per empty bin |
+| `NumData` | Number of observed events (counting experiments only) |
+| `BlindRange` | Range to veto, e.g. `120,130` |
+
+Choose fine enough `Binning` — typically 10× smaller than detector resolution.
+The pseudo-binned dataset introduces bias if bins are too coarse.
+
+### Systematic node attributes
+
+| Attribute | Description |
+|---|---|
+| `Name` | Nuisance parameter name (same name = correlated across categories) |
+| `Constr` | Constraint type: `gaus`, `logn`, `asym`, `dfd` |
+| `CentralValue` | Nominal response value (usually `1`; use `0` for additive) |
+| `Mag` | Uncertainty magnitude; for `asym`: `upper,lower` |
+| `WhereTo` | `yield` (auto-applied) or `shape` (user must place `response::`) |
+| `Process` | Group name for routing to specific samples via `ImportSyst` |
+
+**Constraint types and response functions:**
+
+| Type | Response function |
+|---|---|
+| `gaus` | `CentralValue + NP × Mag` |
+| `logn` | `(1 + Mag/CentralValue)^NP` |
+| `asym` | Polynomial interp within ±1σ, log-normal extrapolation outside |
+| `dfd` | Double-Fermi-Dirac box (for ill-defined uncertainties) |
+
+Signs in `Mag` matter — always follow the sign convention of the upstream tool.
+For `asym`, only the sign of the upper uncertainty is used.
+
+### Sample node attributes
+
+| Attribute | Description |
+|---|---|
+| `Name` | Process name (unique within category) |
+| `InputFile` | Path to pdf-level XML card |
+| `ImportSyst` | Comma-separated common systematic groups; `:common:` = all ungrouped; `:self:` = none |
+| `MultiplyLumi` | Whether to multiply `Lumi` to yield |
+| `SharePdf` | All processes with the same value share a single PDF |
+| `Norm`, `XSection`, `BR`, etc. | Pre-defined constant scale factors on yield |
+
+### NormFactor and ShapeFactor
+
+- `NormFactor`: multiplied automatically to process yield.
+- `ShapeFactor`: available as a building block but not auto-multiplied; user
+  must incorporate it explicitly.
+
+## PDF-Level Card
+
+```xml
+<!DOCTYPE Model SYSTEM 'AnaWSBuilder.dtd'>
+<Model Type="UserDef">
+  <Item Name="mu_CB[125.09]"/>
+  <Item Name="sigma_CB[1.7]"/>
+  <Item Name="prod::mu_smeared(mu_CB, response::ATLAS_EG_SCALE_ALL)"/>
+  <Item Name="prod::sigma_smeared(sigma_CB, response::ATLAS_EG_RESOLUTION_ALL)"/>
+  <ModelItem Name="RooTwoSidedCBShape::signal(:observable:,
+    mu_smeared, sigma_smeared, alphaCBLo[1.9], nCBLo[3.4],
+    alphaCBHi[1.9], nCBHi[3.8])"/>
+</Model>
+```
+
+For an externally provided PDF (e.g. from HistFactory):
+
+```xml
+<Model Type="External" Input="bkg.root" WSName="combined"
+  ModelName="channel_model" ObservableName="obs_x_channel"/>
+```
+
+Keep observable name consistent with HistFactory when importing external PDFs.
+
+## XML Keywords
+
+| Keyword | Meaning |
+|---|---|
+| `response::<NP>` | Response function for NP (in same domain) |
+| `:category:` | Replaced by current category name |
+| `:observable:` | Observable name of current category |
+| `:process:` | Name of current Sample |
+| `:common:` | All ungrouped common systematics |
+| `:self:` | Only process-specific systematics; suppresses `:common:` |
+| `:lt:` `:le:` `:gt:` `:ge:` | `<` `<=` `>` `>=` (XML-safe math symbols) |
+| `:and:` `:or:` | Logic operators for ntuple cuts |
+
+`RooFormulaVar` must use indexed syntax `@0, @1, ...` — never variable names
+(renaming during workspace creation breaks name-based references).
+
+## Counting Experiments
+
+```xml
+<Channel Name="sr" Type="counting" Lumi="20.3">
+  <Data NumData="9" Observable="obs_sr[0,1]"/>
+  <Sample Name="signal" Norm="0.5" ImportSyst=":common:" SharePdf="counting">
+  </Sample>
+</Channel>
+```
+
+- `Type="counting"` creates a `RooUniform` PDF per process.
+- `Binning` is always 1 and is ignored if provided.
+- `NumData` attribute sets event count directly without a data file.
+
+## Blinded Analysis
+
+```xml
+<!-- Top-level: enable blinding -->
+<Combination ... Blind="true">
+
+<!-- Category-level: specify blinded range -->
+<Data ... BlindRange="120,130"/>
+```
+
+Events in `BlindRange` are vetoed. Side-band fits use:
+
+```cpp
+pdf->createNLL(*data, ..., Range("SBLo,SBHi"), SplitRange())
+```
+
+Remove `SBLo` or `SBHi` if the blinded range touches the observable boundary.
+
+## Gotchas
+
+- **`AnaWSBuilder.dtd` location**: must be in every folder containing XML
+  cards — copy or symlink (`ln -s`) from the xmlAnaWSBuilder repo `dtd/`
+  directory.
+- **Fine binning is critical**: pseudo-binned and Asimov datasets are biased
+  when bins are coarse; use ~10× finer than detector resolution.
+- **Indexed proxies in formulas**: `RooFormulaVar` must use `@0, @1, ...`
+  because variables are renamed during workspace construction.
+- **`matchglob` + `reset`**: always call `reset` at the end of any action
+  list containing `matchglob`, otherwise global observable values are altered
+  in the final workspace.
+- **ResponseFunction custom class**: all workspaces produced by xmlAnaWSBuilder
+  contain the `ResponseFunction` class (available in `RooFitExtensions`);
+  downstream tools must have `RooFitExtensions` on `LD_LIBRARY_PATH`.
+- **External HistFactory PDFs**: keep the observable name identical to the
+  HistFactory one; renaming it breaks the binned model.
+
+## Interop
+
+- **workspaceCombiner**: consumes xmlAnaWSBuilder output for multi-channel
+  combinations; observable unique-naming convention is required.
+- **quickFit**: recommended fitting tool for workspaces created by
+  xmlAnaWSBuilder.
+- **StatAnalysis**: `XMLReader` is available after
+  `asetup StatAnalysis,0.7,latest`.
+
+## Support
+
+Contact: xmlanawsbuilder-user@cern.ch
+
+## Docs
+
+https://gitlab.cern.ch/atlas-hgam-sw/xmlAnaWSBuilder

--- a/plugins/atlas/skills/xmlanawsbuilder/SKILL.md
+++ b/plugins/atlas/skills/xmlanawsbuilder/SKILL.md
@@ -30,7 +30,51 @@ and
 xmlAnaWSBuilder is included in the StatAnalysis release. It can also be built
 standalone from: https://gitlab.cern.ch/atlas-hgam-sw/xmlAnaWSBuilder
 
-## Running XMLReader
+## When to Use
+
+- Building an analytic signal or background model for an ATLAS analysis (e.g.
+  H→γγ with double-sided Crystal Ball signal and polynomial or power-law
+  background)
+- Constructing a counting experiment workspace where no shape information is
+  needed
+- Combining multiple analysis categories into a joint likelihood workspace for
+  downstream fitting with quickFit or workspaceCombiner
+- Implementing a blinded analysis with a configurable veto range in the
+  observable
+- Configuring and correlating systematic uncertainties (yield or shape NPs)
+  across categories using the XML card system
+
+## Key Concepts
+
+### Three-Level XML Structure
+
+```text
+top-level card (.xml)
+  └── category-level cards (one per analysis category)
+        └── pdf-level cards (one per physics process per category)
+```
+
+`AnaWSBuilder.dtd` must be present alongside every XML card file.
+
+### XML Keywords
+
+| Keyword                     | Meaning                                                  |
+| --------------------------- | -------------------------------------------------------- |
+| `response::<NP>`            | Response function for NP (in same domain)                |
+| `:category:`                | Replaced by current category name                        |
+| `:observable:`              | Observable name of current category                      |
+| `:process:`                 | Name of current Sample                                   |
+| `:common:`                  | All ungrouped common systematics                         |
+| `:self:`                    | Only process-specific systematics; suppresses `:common:` |
+| `:lt:` `:le:` `:gt:` `:ge:` | `<` `<=` `>` `>=` (XML-safe math symbols)                |
+| `:and:` `:or:`              | Logic operators for ntuple cuts                          |
+
+`RooFormulaVar` must use indexed syntax `@0, @1, ...` — never variable names
+(renaming during workspace creation breaks name-based references).
+
+## Canonical Patterns
+
+### Running XMLReader
 
 ```bash
 XMLReader -x config/myanalysis/top.xml
@@ -51,17 +95,7 @@ XMLReader -x config/top.xml -v               # verbose debug output
 | `-b` / `--binned`             | Fit to binned (pseudo-binned) dataset |
 | `-o` / `--plotOption`         | Plot options (e.g. `logy`, `rebin10`) |
 
-## Three-Level XML Structure
-
-```
-top-level card (.xml)
-  └── category-level cards (one per analysis category)
-        └── pdf-level cards (one per physics process per category)
-```
-
-`AnaWSBuilder.dtd` must be present alongside every XML card file.
-
-## Top-Level Card
+### Top-Level Card
 
 ```xml
 <!DOCTYPE Combination SYSTEM 'AnaWSBuilder.dtd'>
@@ -86,7 +120,7 @@ top-level card (.xml)
 For blinded analysis set `Blind="true"` and add `BlindRange` to each `Data` node
 (see [Blinded Analysis](#blinded-analysis)).
 
-### Asimov action keywords
+#### Asimov action keywords
 
 | Keyword           | Meaning                                                         |
 | ----------------- | --------------------------------------------------------------- |
@@ -101,7 +135,7 @@ For blinded analysis set `Blind="true"` and add `BlindRange` to each `Data` node
 | `float`           | Float NPs fixed by `fixsyst` or `Setup`                         |
 | `<snapshot name>` | Load a saved snapshot                                           |
 
-## Category-Level Card
+### Category-Level Card
 
 ```xml
 <!DOCTYPE Channel SYSTEM 'AnaWSBuilder.dtd'>
@@ -133,7 +167,7 @@ For blinded analysis set `Blind="true"` and add `BlindRange` to each `Data` node
 </Channel>
 ```
 
-### Data node attributes
+#### Data node attributes
 
 | Attribute     | Description                                           |
 | ------------- | ----------------------------------------------------- |
@@ -151,7 +185,7 @@ For blinded analysis set `Blind="true"` and add `BlindRange` to each `Data` node
 Choose fine enough `Binning` — typically 10× smaller than detector resolution.
 The pseudo-binned dataset introduces bias if bins are too coarse.
 
-### Systematic node attributes
+#### Systematic node attributes
 
 | Attribute      | Description                                                        |
 | -------------- | ------------------------------------------------------------------ |
@@ -174,7 +208,7 @@ The pseudo-binned dataset introduces bias if bins are too coarse.
 Signs in `Mag` matter — always follow the sign convention of the upstream tool.
 For `asym`, only the sign of the upper uncertainty is used.
 
-### Sample node attributes
+#### Sample node attributes
 
 | Attribute                      | Description                                                                           |
 | ------------------------------ | ------------------------------------------------------------------------------------- |
@@ -185,13 +219,13 @@ For `asym`, only the sign of the upper uncertainty is used.
 | `SharePdf`                     | All processes with the same value share a single PDF                                  |
 | `Norm`, `XSection`, `BR`, etc. | Pre-defined constant scale factors on yield                                           |
 
-### NormFactor and ShapeFactor
+#### NormFactor and ShapeFactor
 
 - `NormFactor`: multiplied automatically to process yield.
 - `ShapeFactor`: available as a building block but not auto-multiplied; user
   must incorporate it explicitly.
 
-## PDF-Level Card
+### PDF-Level Card
 
 ```xml
 <!DOCTYPE Model SYSTEM 'AnaWSBuilder.dtd'>
@@ -215,23 +249,7 @@ For an externally provided PDF (e.g. from HistFactory):
 
 Keep observable name consistent with HistFactory when importing external PDFs.
 
-## XML Keywords
-
-| Keyword                     | Meaning                                                  |
-| --------------------------- | -------------------------------------------------------- |
-| `response::<NP>`            | Response function for NP (in same domain)                |
-| `:category:`                | Replaced by current category name                        |
-| `:observable:`              | Observable name of current category                      |
-| `:process:`                 | Name of current Sample                                   |
-| `:common:`                  | All ungrouped common systematics                         |
-| `:self:`                    | Only process-specific systematics; suppresses `:common:` |
-| `:lt:` `:le:` `:gt:` `:ge:` | `<` `<=` `>` `>=` (XML-safe math symbols)                |
-| `:and:` `:or:`              | Logic operators for ntuple cuts                          |
-
-`RooFormulaVar` must use indexed syntax `@0, @1, ...` — never variable names
-(renaming during workspace creation breaks name-based references).
-
-## Counting Experiments
+### Counting Experiments
 
 ```xml
 <Channel Name="sr" Type="counting" Lumi="20.3">
@@ -245,7 +263,7 @@ Keep observable name consistent with HistFactory when importing external PDFs.
 - `Binning` is always 1 and is ignored if provided.
 - `NumData` attribute sets event count directly without a data file.
 
-## Blinded Analysis
+### Blinded Analysis
 
 ```xml
 <!-- Top-level: enable blinding -->
@@ -288,8 +306,6 @@ Remove `SBLo` or `SBHi` if the blinded range touches the observable boundary.
   xmlAnaWSBuilder.
 - **StatAnalysis**: `XMLReader` is available after
   `asetup StatAnalysis,0.7,latest`.
-
-## Support
 
 Contact: xmlanawsbuilder-user@cern.ch
 

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -63,6 +63,7 @@ w["pdfs"]["simPdf"]["SR"]          # equivalent
 | Nuisance parameters (α) | ν      | `np()`          | Gaussian-constrained NPs                           |
 | Nuisance parameters (γ) | ν      | `np()`          | Poisson-constrained (MC-stat) NPs                  |
 | All parameters          | θ      | `pars()`        | Everything that is not an observable               |
+| Prespecified parameters |        | `pp()`          | Non-floatable (always constant) parameters         |
 | Floating                |        | `floats()`      | Currently floating subset                          |
 | Constant                |        | `consts()`      | Currently constant subset                          |
 
@@ -284,6 +285,21 @@ systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
   converting.
 - **Tolerance ≤ 10**: Setting `Tolerance > 10` has been observed to cause
   incorrect parameter uncertainties even with covQual=3.
+
+## Additional Resources
+
+For detailed content beyond this overview, consult the reference files:
+
+- **`references/workspace-building.md`** — Factor types (Const, Norm, Simple,
+  Density, Shape, Varied, Overall, Histo), interpolation codes, MC stat
+  handling, SetXaxis, log-normal constraints, SetBinData
+- **`references/fitting-diagnostics.md`** — Full fit config settings
+  (StrategySequence, HesseStrategy), impact/ranking (`fr.impact()`), conditional
+  uncertainties (Schur complement), stat/syst/mc-stat breakdown, Shifted GO
+  method, conditional fits (`fr.cfit()`)
+- **`references/hypothesis-testing.md`** — Test statistic definitions (tmu, qmu,
+  qmutilde, q0, u0), full verbose limit-setting example, toy-based limits, limit
+  troubleshooting, hypoPoint methods/fits tables, limit-setting checklist
 
 ## Interop
 

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: xroofit
+description: >-
+  Use when building RooFit statistical models with xRooFit, constructing
+  workspaces with channels and samples, adding systematics or nuisance
+  parameters, fitting models to data, constructing NLL functions, diagnosing
+  fit convergence failures (status codes, covariance quality), computing
+  profile likelihood ratios, calculating CLs upper limits or exclusion
+  contours, or computing discovery significance.
+---
+
+# xRooFit
+
+## Overview
+
+xRooFit is a high-level Python/C++ API for the RooFit statistical analysis
+toolkit, with the same relationship to RooFit as Keras has to TensorFlow:
+RooFit can be used directly, but xRooFit makes building and fitting models
+significantly more concise. xRooFit ships pre-installed with ROOT ≥ 6.30 and
+is also distributed as part of the ATLAS
+[StatAnalysis](https://gitlab.cern.ch/atlas/StatAnalysis) release.
+
+## Setup
+
+```python
+# Option 1 — StatAnalysis (recommended for ATLAS users)
+# In the shell:
+#   setupATLAS && asetup StatAnalysis,0.7,latest
+import ROOT as XRF               # xRooFit built on top of ROOT
+
+# Option 2 — ROOT's bundled version (≥ 6.30)
+import ROOT
+from ROOT.Experimental import XRooFit as XRF
+```
+
+Using `import ROOT as XRF` (option 1) is the recommended form in the xRooFit
+docs and is used in all examples below. Methods that are specific to the
+built-in version would use `XRF.xRooFit.<method>` in both options.
+
+### Standalone build (if not using StatAnalysis)
+
+```bash
+git clone https://:@gitlab.cern.ch:8443/will/xroofit.git
+cmake -S xroofit -B xroofit_build && cmake --build xroofit_build
+source xroofit_build/setup.sh   # add to PATH each session
+```
+
+Requires ROOT ≥ 6.32 (6.38+ recommended). The StatAnalysis 0.7 branch
+provides ROOT 6.38 on EL9.
+
+## Key Concepts
+
+### xRooNode
+
+All objects in xRooFit are accessed through `xRooNode`, a smart pointer-like
+wrapper that adds methods on top of the underlying RooFit object. In Python,
+unknown attribute access is forwarded to the wrapped object, so workspace
+methods are available directly:
+
+```python
+w = XRF.xRooNode("workspace.root")   # loads first workspace from file
+w.factory("Gaussian::g(x[0,-5,5], mu[0,-3,3], sigma[1])")  # delegates to RooWorkspace
+```
+
+Navigate the workspace hierarchy with path syntax:
+
+```python
+w["pdfs/simPdf/SR/samples/bkg"]   # channel SR, sample bkg
+w["pdfs"]["simPdf"]["SR"]          # equivalent
+```
+
+### Variable types
+
+| Type | Symbol | xRooNode method | Description |
+|---|---|---|---|
+| Regular observables | x | `robs()` | Column in the dataset |
+| Global observables | a | `globs()` | Auxilliary measurements (constraint nominal values) |
+| All observables | | `obs()` | All of the above |
+| Parameters of interest | μ | `poi()` | Floatable, marked as POI |
+| Nuisance parameters (α) | ν | `np()` | Gaussian-constrained NPs |
+| Nuisance parameters (γ) | ν | `np()` | Poisson-constrained (MC-stat) NPs |
+| All parameters | θ | `pars()` | Everything that is not an observable |
+| Floating | | `floats()` | Currently floating subset |
+| Constant | | `consts()` | Currently constant subset |
+
+Mark or unmark parameters:
+
+```python
+w.pars().reduced("alpha_*").setAttribAll("Constant")  # fix all alpha NPs
+w.pars()["mu_sig"].setAttribute("poi")               # promote to POI
+w.floats().Print()                                   # list floating pars
+```
+
+## Canonical Patterns
+
+### Building a workspace from scratch
+
+```python
+import ROOT as XRF
+
+w = XRF.xRooNode("RooWorkspace", "combined", "my workspace")
+
+# Multi-channel (RooSimultaneous) top-level PDF
+w["pdfs"].Add("simPdf")
+
+# Add a channel (RooProdPdf)
+w["pdfs/simPdf"].Add("SR").SetTitle("Signal Region")
+
+# Declare the observable and add a sample from a histogram
+hBkg = ROOT.TH1D("bkg", "Background;m_{T2} [GeV]", 5, 200, 700)
+hBkg.GetXaxis().SetName("mt2")   # observable name
+# ... fill histogram ...
+w["pdfs/simPdf/SR/samples"].Add(hBkg)   # bin errors → automatic MC-stat ShapeSys
+
+# Signal sample
+hSig = ROOT.TH1D("sig", "Signal;m_{T2} [GeV]", 5, 200, 700)
+hSig.GetXaxis().SetName("mt2")
+w["pdfs/simPdf/SR/samples"].Add(hSig)
+
+# Signal-strength NormFactor
+w["pdfs/simPdf/SR/samples/sig"].coefs().Multiply("mu_sig", "norm")
+
+# Observed data
+hData = ROOT.TH1D("obsData", "Data;m_{T2} [GeV]", 5, 200, 700)
+# ... fill histogram ...
+hData.SetName("obsData")
+w["pdfs/simPdf/SR"].datasets().Add(hData)
+```
+
+### Adding systematics
+
+```python
+# Overall (normalization) systematic — creates a NormFactor + Gaussian constraint
+w["pdfs/simPdf/SR/samples/bkg"].coefs().Multiply("mu_bkg", "norm")
+w["pdfs/simPdf"].pars()["alpha_JES"].Constrain("normal")  # adds Gaussian constraint
+
+# Histo (shape+norm) systematic via histograms
+hJESup = ROOT.TH1D("JES=1", ...)   # name must follow convention: parName=value
+hJESdn = ROOT.TH1D("JES=-1", ...)
+w["pdfs/simPdf/SR/samples/bkg"].Vary(hJESup)
+w["pdfs/simPdf/SR/samples/bkg"].Vary(hJESdn)
+
+# Or set a single bin variation:
+w["pdfs/simPdf/SR/samples/bkg"].SetBinContent(3, new_val, "alpha_JES", 1)
+```
+
+### Loading an existing workspace
+
+```python
+w = XRF.xRooNode("workspace.root")
+# or
+f = ROOT.TFile("workspace.root")
+ws = f.Get("combined")
+w = XRF.xRooNode(ws)
+```
+
+### Fitting
+
+```python
+nll = w["pdfs/simPdf"].nll("obsData")   # construct NLL
+fr  = nll.minimize()                    # fit; returns RooFitResult
+fr.Draw()                               # post-fit parameter pulls
+fr.Draw("CORR10 COLZ TEXT")             # top-10 off-diagonal correlations
+
+# Check convergence (must have status=0, covQual=3 for a valid fit)
+print(fr.status(), fr.covQual())
+
+# Asymmetric (MINOS) uncertainties for a specific parameter
+nll.pars().find("mu_sig").setAttribute("minos")
+fr = nll.minimize()
+fr.floatParsFinal().find("mu_sig").getErrorHi()
+fr.floatParsFinal().find("mu_sig").getErrorLo()
+```
+
+### Fit status and covariance quality
+
+| Code | Meaning |
+|---|---|
+| status=0 | Last algorithm ran successfully (valid fit) |
+| status=1 | Covariance forced positive-definite → try higher Strategy |
+| status=2 | Covariance invalid (Hesse strategy 3 only) |
+| status=3 | EDM above threshold → increase Tolerance (max ~10) |
+| status≥4 | Fit cannot be trusted |
+| covQual=3 | Positive-definite covariance (required) |
+| covQual=2 | Forced positive-definite (status=1) |
+| covQual=1 | Approximation only (status=2) |
+| covQual=0 | Unavailable (no floating parameters) |
+
+Tune fit hyperparameters:
+
+```python
+nll = w["pdfs/simPdf"].nll("obsData", [XRF.xRooFit.Tolerance(1),
+                                        ROOT.RooFit.Strategy(2)])
+# or after construction:
+nll.fitConfig().MinimizerOptions().SetTolerance(1)
+nll.fitConfig().MinimizerOptions().SetStrategy(2)
+```
+
+### Profile likelihood scan
+
+```python
+hs = nll.hypoSpace("mu_sig")
+hs.scan("plr", 20, 0, 3)   # 20 points between 0 and 3
+hs.Draw()
+```
+
+### CLs upper limits (asymptotic)
+
+```python
+import ROOT as XRF
+
+w   = XRF.xRooNode("workspace.root")
+nll = w["simPdf"].nll("obsData")
+hs  = nll.hypoSpace("mu_sig", XRF.xRooFit.TestStatistic.qmutilde)
+
+hs.scan("cls visualize", 0, 0, 10)   # auto-scan; visualize shows progress
+limits = hs.limits()   # dict keyed by "-2","-1","0","1","2","obs"
+print(limits)
+
+# Minimal version (POI must be pre-declared in workspace):
+print(w.nll("obsData").hypoSpace().limits())
+```
+
+Available test statistics: `tmu`, `qmu`, `qmutilde` (default for upper
+limits), `q0`, `u0` (for discovery).
+
+### Discovery significance
+
+```python
+hs = nll.hypoSpace("mu_sig", XRF.xRooFit.TestStatistic.u0)
+hs.scan("pnull", 1, 0, 0)   # single point at mu=0
+
+print("Observed p0:", hs[0].pNull_asymp())
+print("Expected p0:", hs[0].pNull_asymp(0))
+# convert to significance:
+sig = ROOT.Math.gaussian_quantile_c(hs[0].pNull_asymp().value(), 1)
+```
+
+### Goodness of fit
+
+```python
+nll.mainTermPgof()   # p-value (main term only, recommended for observed data)
+nll.pgof()           # p-value including constraint term (use for toys only)
+```
+
+### Uncertainty breakdown
+
+```python
+totErr  = fr.floatParsFinal().find("mu_sig").getError()
+statErr = fr.conditionalError("mu_sig", "alpha_*,gamma_*", up=True, approx=True)
+systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
+```
+
+## Gotchas
+
+- **Two import styles, one namespace**: Both
+  `import ROOT as XRF` (standalone build) and
+  `from ROOT.Experimental import XRooFit as XRF` (bundled) give you an `XRF`
+  namespace. The standalone build adds methods directly to `ROOT`; the bundled
+  version exposes them under `ROOT.Experimental.XRooFit`.
+- **Bin errors trigger MC-stat ShapeSys**: If you add a histogram with
+  non-zero bin errors, xRooFit automatically creates a `ShapeSys` for MC
+  statistical uncertainties. Suppress this by zeroing out bin errors before
+  adding, or control the prefix with `hBkg.SetOption("statPrefix=stat_SR")`.
+- **Variation histograms must have zero bin errors**: When calling `Vary()`,
+  ensure variation histograms have no bin errors to avoid errors-on-errors.
+- **Histogram names encode parameter values**: Variations must be named
+  `parName=value`, e.g. `JES=1`, `JES=-1`.
+- **Python method forwarding**: In Python, `w["path"].someMethod()` can call
+  either `xRooNode.someMethod()` or the underlying RooFit object's method. In
+  C++ you must use `w["path"].get<ClassName>()->someMethod()`.
+- **All energies in MeV in ATLAS**: When setting axis ranges for observables
+  derived from reconstructed physics objects, use MeV not GeV unless
+  explicitly converting.
+- **Tolerance ≤ 10**: Setting `Tolerance > 10` has been observed to cause
+  incorrect parameter uncertainties even with covQual=3.
+
+## Interop
+
+- **StatAnalysis**: Preferred environment; provides ROOT 6.38 + xRooFit + all
+  ATLAS stat tools on EL9.
+- **TRExFitter**: TRExFitter workspaces are HistFactory/RooStats XML; load
+  with `xRooNode("workspace.root")` after running `trex-fitter w`.
+- **pyhf**: Convert HistFactory XML to pyhf JSON with
+  `pyhf xml2json`; or use pyhf's workspace directly (not xRooFit format).
+- **cabinetry**: Reads pyhf JSON workspaces and produces ROOT-style diagnostic
+  plots; complementary to xRooFit.
+- **xRooBrowser**: Interactive ROOT GUI
+  (`ROOT::Experimental::RooBrowser` in ROOT 6.28+) for exploring workspaces.
+
+## Docs
+
+https://xroofit.readthedocs.io/

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -286,6 +286,19 @@ systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
 - **Tolerance ≤ 10**: Setting `Tolerance > 10` has been observed to cause
   incorrect parameter uncertainties even with covQual=3.
 
+## Interop
+
+- **StatAnalysis**: Preferred environment; provides ROOT 6.38 + xRooFit + all
+  ATLAS stat tools on EL9.
+- **TRExFitter**: TRExFitter workspaces are HistFactory/RooStats XML; load with
+  `xRooNode("workspace.root")` after running `trex-fitter w`.
+- **pyhf**: Convert HistFactory XML to pyhf JSON with `pyhf xml2json`; or use
+  pyhf's workspace directly (not xRooFit format).
+- **cabinetry**: Reads pyhf JSON workspaces and produces ROOT-style diagnostic
+  plots; complementary to xRooFit.
+- **xRooBrowser**: Interactive ROOT GUI (`ROOT::Experimental::RooBrowser` in
+  ROOT 6.28+) for exploring workspaces.
+
 ## Additional Resources
 
 For detailed content beyond this overview, consult the reference files:
@@ -300,19 +313,6 @@ For detailed content beyond this overview, consult the reference files:
 - **`references/hypothesis-testing.md`** — Test statistic definitions (tmu, qmu,
   qmutilde, q0, u0), full verbose limit-setting example, toy-based limits, limit
   troubleshooting, hypoPoint methods/fits tables, limit-setting checklist
-
-## Interop
-
-- **StatAnalysis**: Preferred environment; provides ROOT 6.38 + xRooFit + all
-  ATLAS stat tools on EL9.
-- **TRExFitter**: TRExFitter workspaces are HistFactory/RooStats XML; load with
-  `xRooNode("workspace.root")` after running `trex-fitter w`.
-- **pyhf**: Convert HistFactory XML to pyhf JSON with `pyhf xml2json`; or use
-  pyhf's workspace directly (not xRooFit format).
-- **cabinetry**: Reads pyhf JSON workspaces and produces ROOT-style diagnostic
-  plots; complementary to xRooFit.
-- **xRooBrowser**: Interactive ROOT GUI (`ROOT::Experimental::RooBrowser` in
-  ROOT 6.28+) for exploring workspaces.
 
 ## Docs
 

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -31,34 +31,6 @@ also distributed as part of the ATLAS
 - Choosing ROOT/RooFit-based statistics over pyhf when C++ performance, custom
   RooFit classes, or direct RooStats infrastructure access is required
 
-## Setup
-
-```python
-# Option 1 — StatAnalysis (recommended for ATLAS users)
-# In the shell:
-#   setupATLAS && asetup StatAnalysis,0.7,latest
-import ROOT as XRF               # xRooFit built on top of ROOT
-
-# Option 2 — ROOT's bundled version (≥ 6.30)
-import ROOT
-from ROOT.Experimental import XRooFit as XRF
-```
-
-Using `import ROOT as XRF` (option 1) is the recommended form in the xRooFit
-docs and is used in all examples below. Methods that are specific to the
-built-in version would use `XRF.xRooFit.<method>` in both options.
-
-### Standalone build (if not using StatAnalysis)
-
-```bash
-git clone https://:@gitlab.cern.ch:8443/will/xroofit.git
-cmake -S xroofit -B xroofit_build && cmake --build xroofit_build
-source xroofit_build/setup.sh   # add to PATH each session
-```
-
-Requires ROOT ≥ 6.32 (6.38+ recommended). The StatAnalysis 0.7 branch provides
-ROOT 6.38 on EL9.
-
 ## Key Concepts
 
 ### xRooNode
@@ -103,6 +75,34 @@ w.floats().Print()                                   # list floating pars
 ```
 
 ## Canonical Patterns
+
+### Setup
+
+```python
+# Option 1 — StatAnalysis (recommended for ATLAS users)
+# In the shell:
+#   setupATLAS && asetup StatAnalysis,0.7,latest
+import ROOT as XRF               # xRooFit built on top of ROOT
+
+# Option 2 — ROOT's bundled version (≥ 6.30)
+import ROOT
+from ROOT.Experimental import XRooFit as XRF
+```
+
+Using `import ROOT as XRF` (option 1) is the recommended form in the xRooFit
+docs and is used in all examples below. Methods that are specific to the
+built-in version would use `XRF.xRooFit.<method>` in both options.
+
+#### Standalone build (if not using StatAnalysis)
+
+```bash
+git clone https://:@gitlab.cern.ch:8443/will/xroofit.git
+cmake -S xroofit -B xroofit_build && cmake --build xroofit_build
+source xroofit_build/setup.sh   # add to PATH each session
+```
+
+Requires ROOT ≥ 6.32 (6.38+ recommended). The StatAnalysis 0.7 branch provides
+ROOT 6.38 on EL9.
 
 ### Building a workspace from scratch
 

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -221,7 +221,7 @@ hs.Draw()
 import ROOT as XRF
 
 w   = XRF.xRooNode("workspace.root")
-nll = w["simPdf"].nll("obsData")
+nll = w["pdfs/simPdf"].nll("obsData")
 hs  = nll.hypoSpace("mu_sig", XRF.xRooFit.TestStatistic.qmutilde)
 
 hs.scan("cls visualize", 0, 0, 10)   # auto-scan; visualize shows progress

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -3,10 +3,10 @@ name: xroofit
 description: >-
   Use when building RooFit statistical models with xRooFit, constructing
   workspaces with channels and samples, adding systematics or nuisance
-  parameters, fitting models to data, constructing NLL functions, diagnosing
-  fit convergence failures (status codes, covariance quality), computing
-  profile likelihood ratios, calculating CLs upper limits or exclusion
-  contours, or computing discovery significance.
+  parameters, fitting models to data, constructing NLL functions, diagnosing fit
+  convergence failures (status codes, covariance quality), computing profile
+  likelihood ratios, calculating CLs upper limits or exclusion contours, or
+  computing discovery significance.
 ---
 
 # xRooFit
@@ -14,10 +14,10 @@ description: >-
 ## Overview
 
 xRooFit is a high-level Python/C++ API for the RooFit statistical analysis
-toolkit, with the same relationship to RooFit as Keras has to TensorFlow:
-RooFit can be used directly, but xRooFit makes building and fitting models
-significantly more concise. xRooFit ships pre-installed with ROOT ≥ 6.30 and
-is also distributed as part of the ATLAS
+toolkit, with the same relationship to RooFit as Keras has to TensorFlow: RooFit
+can be used directly, but xRooFit makes building and fitting models
+significantly more concise. xRooFit ships pre-installed with ROOT ≥ 6.30 and is
+also distributed as part of the ATLAS
 [StatAnalysis](https://gitlab.cern.ch/atlas/StatAnalysis) release.
 
 ## Setup
@@ -45,8 +45,8 @@ cmake -S xroofit -B xroofit_build && cmake --build xroofit_build
 source xroofit_build/setup.sh   # add to PATH each session
 ```
 
-Requires ROOT ≥ 6.32 (6.38+ recommended). The StatAnalysis 0.7 branch
-provides ROOT 6.38 on EL9.
+Requires ROOT ≥ 6.32 (6.38+ recommended). The StatAnalysis 0.7 branch provides
+ROOT 6.38 on EL9.
 
 ## Key Concepts
 
@@ -71,17 +71,17 @@ w["pdfs"]["simPdf"]["SR"]          # equivalent
 
 ### Variable types
 
-| Type | Symbol | xRooNode method | Description |
-|---|---|---|---|
-| Regular observables | x | `robs()` | Column in the dataset |
-| Global observables | a | `globs()` | Auxilliary measurements (constraint nominal values) |
-| All observables | | `obs()` | All of the above |
-| Parameters of interest | μ | `poi()` | Floatable, marked as POI |
-| Nuisance parameters (α) | ν | `np()` | Gaussian-constrained NPs |
-| Nuisance parameters (γ) | ν | `np()` | Poisson-constrained (MC-stat) NPs |
-| All parameters | θ | `pars()` | Everything that is not an observable |
-| Floating | | `floats()` | Currently floating subset |
-| Constant | | `consts()` | Currently constant subset |
+| Type                    | Symbol | xRooNode method | Description                                        |
+| ----------------------- | ------ | --------------- | -------------------------------------------------- |
+| Regular observables     | x      | `robs()`        | Column in the dataset                              |
+| Global observables      | a      | `globs()`       | Auxiliary measurements (constraint nominal values) |
+| All observables         |        | `obs()`         | All of the above                                   |
+| Parameters of interest  | μ      | `poi()`         | Floatable, marked as POI                           |
+| Nuisance parameters (α) | ν      | `np()`          | Gaussian-constrained NPs                           |
+| Nuisance parameters (γ) | ν      | `np()`          | Poisson-constrained (MC-stat) NPs                  |
+| All parameters          | θ      | `pars()`        | Everything that is not an observable               |
+| Floating                |        | `floats()`      | Currently floating subset                          |
+| Constant                |        | `consts()`      | Currently constant subset                          |
 
 Mark or unmark parameters:
 
@@ -174,17 +174,17 @@ fr.floatParsFinal().find("mu_sig").getErrorLo()
 
 ### Fit status and covariance quality
 
-| Code | Meaning |
-|---|---|
-| status=0 | Last algorithm ran successfully (valid fit) |
-| status=1 | Covariance forced positive-definite → try higher Strategy |
-| status=2 | Covariance invalid (Hesse strategy 3 only) |
-| status=3 | EDM above threshold → increase Tolerance (max ~10) |
-| status≥4 | Fit cannot be trusted |
-| covQual=3 | Positive-definite covariance (required) |
-| covQual=2 | Forced positive-definite (status=1) |
-| covQual=1 | Approximation only (status=2) |
-| covQual=0 | Unavailable (no floating parameters) |
+| Code      | Meaning                                                   |
+| --------- | --------------------------------------------------------- |
+| status=0  | Last algorithm ran successfully (valid fit)               |
+| status=1  | Covariance forced positive-definite → try higher Strategy |
+| status=2  | Covariance invalid (Hesse strategy 3 only)                |
+| status=3  | EDM above threshold → increase Tolerance (max ~10)        |
+| status≥4  | Fit cannot be trusted                                     |
+| covQual=3 | Positive-definite covariance (required)                   |
+| covQual=2 | Forced positive-definite (status=1)                       |
+| covQual=1 | Approximation only (status=2)                             |
+| covQual=0 | Unavailable (no floating parameters)                      |
 
 Tune fit hyperparameters:
 
@@ -221,8 +221,8 @@ print(limits)
 print(w.nll("obsData").hypoSpace().limits())
 ```
 
-Available test statistics: `tmu`, `qmu`, `qmutilde` (default for upper
-limits), `q0`, `u0` (for discovery).
+Available test statistics: `tmu`, `qmu`, `qmutilde` (default for upper limits),
+`q0`, `u0` (for discovery).
 
 ### Discovery significance
 
@@ -253,15 +253,14 @@ systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
 
 ## Gotchas
 
-- **Two import styles, one namespace**: Both
-  `import ROOT as XRF` (standalone build) and
-  `from ROOT.Experimental import XRooFit as XRF` (bundled) give you an `XRF`
-  namespace. The standalone build adds methods directly to `ROOT`; the bundled
-  version exposes them under `ROOT.Experimental.XRooFit`.
-- **Bin errors trigger MC-stat ShapeSys**: If you add a histogram with
-  non-zero bin errors, xRooFit automatically creates a `ShapeSys` for MC
-  statistical uncertainties. Suppress this by zeroing out bin errors before
-  adding, or control the prefix with `hBkg.SetOption("statPrefix=stat_SR")`.
+- **Two import styles, one namespace**: Both `import ROOT as XRF` (standalone
+  build) and `from ROOT.Experimental import XRooFit as XRF` (bundled) give you
+  an `XRF` namespace. The standalone build adds methods directly to `ROOT`; the
+  bundled version exposes them under `ROOT.Experimental.XRooFit`.
+- **Bin errors trigger MC-stat ShapeSys**: If you add a histogram with non-zero
+  bin errors, xRooFit automatically creates a `ShapeSys` for MC statistical
+  uncertainties. Suppress this by zeroing out bin errors before adding, or
+  control the prefix with `hBkg.SetOption("statPrefix=stat_SR")`.
 - **Variation histograms must have zero bin errors**: When calling `Vary()`,
   ensure variation histograms have no bin errors to avoid errors-on-errors.
 - **Histogram names encode parameter values**: Variations must be named
@@ -270,8 +269,8 @@ systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
   either `xRooNode.someMethod()` or the underlying RooFit object's method. In
   C++ you must use `w["path"].get<ClassName>()->someMethod()`.
 - **All energies in MeV in ATLAS**: When setting axis ranges for observables
-  derived from reconstructed physics objects, use MeV not GeV unless
-  explicitly converting.
+  derived from reconstructed physics objects, use MeV not GeV unless explicitly
+  converting.
 - **Tolerance ≤ 10**: Setting `Tolerance > 10` has been observed to cause
   incorrect parameter uncertainties even with covQual=3.
 
@@ -279,14 +278,14 @@ systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
 
 - **StatAnalysis**: Preferred environment; provides ROOT 6.38 + xRooFit + all
   ATLAS stat tools on EL9.
-- **TRExFitter**: TRExFitter workspaces are HistFactory/RooStats XML; load
-  with `xRooNode("workspace.root")` after running `trex-fitter w`.
-- **pyhf**: Convert HistFactory XML to pyhf JSON with
-  `pyhf xml2json`; or use pyhf's workspace directly (not xRooFit format).
+- **TRExFitter**: TRExFitter workspaces are HistFactory/RooStats XML; load with
+  `xRooNode("workspace.root")` after running `trex-fitter w`.
+- **pyhf**: Convert HistFactory XML to pyhf JSON with `pyhf xml2json`; or use
+  pyhf's workspace directly (not xRooFit format).
 - **cabinetry**: Reads pyhf JSON workspaces and produces ROOT-style diagnostic
   plots; complementary to xRooFit.
-- **xRooBrowser**: Interactive ROOT GUI
-  (`ROOT::Experimental::RooBrowser` in ROOT 6.28+) for exploring workspaces.
+- **xRooBrowser**: Interactive ROOT GUI (`ROOT::Experimental::RooBrowser` in
+  ROOT 6.28+) for exploring workspaces.
 
 ## Docs
 

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -20,6 +20,17 @@ significantly more concise. xRooFit ships pre-installed with ROOT ≥ 6.30 and i
 also distributed as part of the ATLAS
 [StatAnalysis](https://gitlab.cern.ch/atlas/StatAnalysis) release.
 
+## When to Use
+
+- Building HistFactory-style statistical models programmatically with Python or
+  C++ as an alternative to TRExFitter config files or HistFactory XML
+- Manipulating or inspecting workspaces produced by TRExFitter or HistFitter
+- Performing CLs upper limits, exclusion contours, or discovery significance
+  tests using asymptotic formulae on a RooFit workspace
+- Diagnosing fit convergence problems via status codes and covariance quality
+- Choosing ROOT/RooFit-based statistics over pyhf when C++ performance, custom
+  RooFit classes, or direct RooStats infrastructure access is required
+
 ## Setup
 
 ```python

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -147,8 +147,8 @@ w["pdfs/simPdf/SR/samples/bkg"].coefs().Multiply("mu_bkg", "norm")
 w["pdfs/simPdf"].pars()["alpha_JES"].Constrain("normal")  # adds Gaussian constraint
 
 # Histo (shape+norm) systematic via histograms
-hJESup = ROOT.TH1D("JES=1", ...)   # name must follow convention: parName=value
-hJESdn = ROOT.TH1D("JES=-1", ...)
+hJESup = XRF.TH1D("JES=1", ...)   # name must follow convention: parName=value
+hJESdn = XRF.TH1D("JES=-1", ...)
 w["pdfs/simPdf/SR/samples/bkg"].Vary(hJESup)
 w["pdfs/simPdf/SR/samples/bkg"].Vary(hJESdn)
 
@@ -161,7 +161,7 @@ w["pdfs/simPdf/SR/samples/bkg"].SetBinContent(3, new_val, "alpha_JES", 1)
 ```python
 w = XRF.xRooNode("workspace.root")
 # or
-f = ROOT.TFile("workspace.root")
+f = XRF.TFile("workspace.root")
 ws = f.Get("combined")
 w = XRF.xRooNode(ws)
 ```
@@ -202,7 +202,7 @@ Tune fit hyperparameters:
 
 ```python
 nll = w["pdfs/simPdf"].nll("obsData", [XRF.xRooFit.Tolerance(1),
-                                        ROOT.RooFit.Strategy(2)])
+                                        XRF.RooFit.Strategy(2)])
 # or after construction:
 nll.fitConfig().MinimizerOptions().SetTolerance(1)
 nll.fitConfig().MinimizerOptions().SetStrategy(2)
@@ -245,7 +245,7 @@ hs.scan("pnull", 1, 0, 0)   # single point at mu=0
 print("Observed p0:", hs[0].pNull_asymp())
 print("Expected p0:", hs[0].pNull_asymp(0))
 # convert to significance:
-sig = ROOT.Math.gaussian_quantile_c(hs[0].pNull_asymp().value(), 1)
+sig = XRF.Math.gaussian_quantile_c(hs[0].pNull_asymp().value(), 1)
 ```
 
 ### Goodness of fit
@@ -260,7 +260,7 @@ nll.pgof()           # p-value including constraint term (use for toys only)
 ```python
 totErr  = fr.floatParsFinal().find("mu_sig").getError()
 statErr = fr.conditionalError("mu_sig", "alpha_*,gamma_*", up=True, approx=True)
-systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
+systErr = XRF.TMath.Sqrt(totErr**2 - statErr**2)
 ```
 
 ## Gotchas

--- a/plugins/atlas/skills/xroofit/SKILL.md
+++ b/plugins/atlas/skills/xroofit/SKILL.md
@@ -119,13 +119,13 @@ w["pdfs"].Add("simPdf")
 w["pdfs/simPdf"].Add("SR").SetTitle("Signal Region")
 
 # Declare the observable and add a sample from a histogram
-hBkg = ROOT.TH1D("bkg", "Background;m_{T2} [GeV]", 5, 200, 700)
+hBkg = XRF.TH1D("bkg", "Background;m_{T2} [GeV]", 5, 200, 700)
 hBkg.GetXaxis().SetName("mt2")   # observable name
 # ... fill histogram ...
 w["pdfs/simPdf/SR/samples"].Add(hBkg)   # bin errors → automatic MC-stat ShapeSys
 
 # Signal sample
-hSig = ROOT.TH1D("sig", "Signal;m_{T2} [GeV]", 5, 200, 700)
+hSig = XRF.TH1D("sig", "Signal;m_{T2} [GeV]", 5, 200, 700)
 hSig.GetXaxis().SetName("mt2")
 w["pdfs/simPdf/SR/samples"].Add(hSig)
 
@@ -133,7 +133,7 @@ w["pdfs/simPdf/SR/samples"].Add(hSig)
 w["pdfs/simPdf/SR/samples/sig"].coefs().Multiply("mu_sig", "norm")
 
 # Observed data
-hData = ROOT.TH1D("obsData", "Data;m_{T2} [GeV]", 5, 200, 700)
+hData = XRF.TH1D("obsData", "Data;m_{T2} [GeV]", 5, 200, 700)
 # ... fill histogram ...
 hData.SetName("obsData")
 w["pdfs/simPdf/SR"].datasets().Add(hData)
@@ -299,7 +299,11 @@ systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
 - **xRooBrowser**: Interactive ROOT GUI (`ROOT::Experimental::RooBrowser` in
   ROOT 6.28+) for exploring workspaces.
 
-## Additional Resources
+## Docs
+
+https://xroofit.readthedocs.io/
+
+### Additional Resources
 
 For detailed content beyond this overview, consult the reference files:
 
@@ -313,7 +317,3 @@ For detailed content beyond this overview, consult the reference files:
 - **`references/hypothesis-testing.md`** — Test statistic definitions (tmu, qmu,
   qmutilde, q0, u0), full verbose limit-setting example, toy-based limits, limit
   troubleshooting, hypoPoint methods/fits tables, limit-setting checklist
-
-## Docs
-
-https://xroofit.readthedocs.io/

--- a/plugins/atlas/skills/xroofit/references/fitting-diagnostics.md
+++ b/plugins/atlas/skills/xroofit/references/fitting-diagnostics.md
@@ -1,0 +1,178 @@
+# Advanced Fitting and Diagnostics
+
+## Fit Configuration
+
+The NLL function carries its own fit config. View the current settings
+with `nll.Print()`. Settings can be passed as NLL options or changed
+after construction.
+
+### Fit Config Settings
+
+| Setting               | NLL option                                        | Post-construction                                           | Description |
+| --------------------- | ------------------------------------------------- | ----------------------------------------------------------- | ----------- |
+| Tolerance             | `XRF.xRooFit.Tolerance(0.01)`                    | `nll.fitConfig().MinimizerOptions().SetTolerance(0.01)`     | Tolerance = 1000 × max EDM. Default 0.01 → max EDM of 1e-5. **Do not set above 10.** |
+| Strategy              | `ROOT.RooFit.Strategy(-1)`                        | `nll.fitConfig().MinimizerOptions().SetStrategy(-1)`        | Starting Minuit strategy. -1 = use first in StrategySequence. |
+| StrategySequence      | `XRF.xRooFit.StrategySequence("0s01s12s2s3m")`   | `nll.fitConfigOptions().SetValue("StrategySequence", ...)`  | Retry sequence on failure. Numbers = strategy, s = rescan, m = minuit1. |
+| Hesse                 | `ROOT.RooFit.Hesse(True)`                         | `nll.fitConfig().SetParabErrors(True)`                      | Run Hesse after Migrad for accurate covariance. |
+| HesseStrategy         | n/a                                                | `nll.fitConfigOptions().SetValue("HesseStrategy", -1)`      | Starting Hesse strategy. -1 = first in HesseStrategySequence. |
+| HesseStrategySequence | n/a                                                | `nll.fitConfigOptions().SetValue("HesseStrategySequence", "23")` | Retry sequence for Hesse algorithm. |
+
+### Strategy Details
+
+| Strategy | Method                                    | Speed   |
+| -------- | ----------------------------------------- | ------- |
+| 0        | Iterative Hessian approximation           | Fastest |
+| 1        | Not advised as starting strategy          |         |
+| 2        | Hesse with forward finite-difference      | Slower  |
+| 3        | Hesse with central finite-difference      | 4× cost of strategy 2 |
+
+**General approach**: start with low strategy, increase tolerance until
+fits converge, then increase strategy if the post-Hesse EDM exceeds the
+tolerance threshold.
+
+## Correlation Matrix
+
+After fitting, always inspect the correlation matrix:
+
+```python
+fr.Draw("CORR COLZ TEXT")      # full correlation matrix
+fr.Draw("CORR10 COLZ TEXT")    # top-10 off-diagonal correlations
+```
+
+Correlations above ~80% indicate potentially degenerate parameters where
+different points in parameter space produce nearly identical model
+predictions. The covariance matrix (and symmetric uncertainties) cannot
+be trusted when the likelihood minimum is poorly defined due to
+degeneracy.
+
+## Impact and Ranking
+
+Impact measures how much a parameter of interest μ shifts when a
+nuisance parameter ν is moved by its uncertainty and held constant:
+
+Δ_{ν±}μ = μ̂̂(ν=ν̂+Δ±ν) − μ̂
+
+### Computing Impact
+
+```python
+# Exact impact (triggers conditional fits)
+fr.impact("mu_sig", "alpha_JES", up=True)
+fr.impact("mu_sig", "alpha_JES", up=True, prefit=True)
+
+# Approximated from covariance matrix (no extra fits)
+fr.impact("mu_sig", "alpha_JES", up=True, approx=True)
+fr.impact("mu_sig", "alpha_JES", up=True, prefit=True, approx=True)
+```
+
+### Relationship to Correlation
+
+Impact ranking is approximately the same as ranking correlation
+coefficients:
+
+Δ_{ν±}μ ≈ cov(μ,ν) / (±Δν) = corr(μ,ν) · (±Δμ)
+
+## Conditional Uncertainties and Uncertainty Breakdowns
+
+The conditional uncertainty on μ when holding ν constant at its post-fit
+value is:
+
+Δμ(ν=ν̂) ≈ √(cov(μ,μ) − cov(μ,ν)²/cov(ν,ν))
+
+For multiple conditioned parameters, use the Schur complement of the
+covariance matrix block decomposition.
+
+### Computing Conditional Uncertainties
+
+```python
+cError = fr.conditionalError("mu_sig", "alpha_*,gamma_*",
+                              up=True, approx=True)
+```
+
+Wildcards are supported in the parameter list.
+
+### Stat/Syst/MC-stat Breakdown
+
+```python
+totErr = fr.floatParsFinal().find("mu_sig").getError()
+
+# Statistical uncertainty (condition on all systematics)
+statErr = fr.conditionalError("mu_sig", "alpha_*,gamma_*",
+                               up=True, approx=True)
+systErr = ROOT.TMath.Sqrt(totErr**2 - statErr**2)
+
+# Further breakdown: model-syst vs mc-stat
+statAndMCStatErr = fr.conditionalError("mu_sig", "alpha_*",
+                                        up=True, approx=True)
+modSystErr = ROOT.TMath.Sqrt(totErr**2 - statAndMCStatErr**2)
+mcStatErr = ROOT.TMath.Sqrt(statAndMCStatErr**2 - statErr**2)
+```
+
+### Shifted Global Observables (Shifted GO) Method
+
+A newer (2025) technique for systematic uncertainty breakdowns using
+quadrature sum of covariance-approximated prefit impacts:
+
+```python
+systErr = ROOT.TMath.Sqrt(
+    sum([
+        pow(fr.impact("mu_sig", np.GetName(),
+                       up=True, prefit=True, approx=True), 2)
+        for np in w.np().reduced("alpha_*", "gamma_*")
+    ])
+)
+```
+
+## Conditional Fits
+
+Perform conditional fits (holding parameters at specific values) using
+the fit result:
+
+```python
+fr = nll.minimize()
+cfr = fr.cfit("mu_sig=1.5")  # conditional fit with mu_sig fixed at 1.5
+print(cfr.status(), cfr.covQual())
+print(2 * (cfr.minNll() - fr.minNll()))  # 2×PLR value
+```
+
+## Profile Likelihood Scan (Manual)
+
+Build a PLR scan manually using conditional fits:
+
+```python
+fr = nll.minimize()
+g = ROOT.TGraph()
+v = minVal
+while v < maxVal:
+    cfr = fr.cfit(f"mu_sig={v}")
+    g.AddPoint(v, 2 * (cfr.minNll() - fr.minNll()))
+    v += (maxVal - minVal) / (nPoints - 1)
+g.Draw("ALP")
+```
+
+## Goodness of Fit (Extended)
+
+xRooFit uses the **saturated model** to compute goodness-of-fit
+p-values. The saturated model likelihood ratio test statistic is assumed
+χ²-distributed.
+
+### Main-Term Only (Recommended for Observed Data)
+
+```python
+nll.mainTerm().getVal()     # current main-term NLL
+nll.saturatedMainTerm()     # saturated main-term NLL
+nll.mainTermNdof()          # nBins - nUnconstrained
+nll.mainTermPgof()          # p-value
+```
+
+### Including Constraint Term (Valid for Toys Only)
+
+The constraint term's global observable nominal values bias the p-value
+towards larger values for observed data. Use this version only for toy
+datasets.
+
+```python
+nll.getVal()          # full NLL
+nll.saturatedVal()    # saturated full NLL
+nll.ndof()            # nBins + nGlobs - nFloats
+nll.pgof()            # p-value
+```

--- a/plugins/atlas/skills/xroofit/references/fitting-diagnostics.md
+++ b/plugins/atlas/skills/xroofit/references/fitting-diagnostics.md
@@ -2,33 +2,33 @@
 
 ## Fit Configuration
 
-The NLL function carries its own fit config. View the current settings
-with `nll.Print()`. Settings can be passed as NLL options or changed
-after construction.
+The NLL function carries its own fit config. View the current settings with
+`nll.Print()`. Settings can be passed as NLL options or changed after
+construction.
 
 ### Fit Config Settings
 
-| Setting               | NLL option                                        | Post-construction                                           | Description |
-| --------------------- | ------------------------------------------------- | ----------------------------------------------------------- | ----------- |
-| Tolerance             | `XRF.xRooFit.Tolerance(0.01)`                    | `nll.fitConfig().MinimizerOptions().SetTolerance(0.01)`     | Tolerance = 1000 × max EDM. Default 0.01 → max EDM of 1e-5. **Do not set above 10.** |
-| Strategy              | `ROOT.RooFit.Strategy(-1)`                        | `nll.fitConfig().MinimizerOptions().SetStrategy(-1)`        | Starting Minuit strategy. -1 = use first in StrategySequence. |
-| StrategySequence      | `XRF.xRooFit.StrategySequence("0s01s12s2s3m")`   | `nll.fitConfigOptions().SetValue("StrategySequence", ...)`  | Retry sequence on failure. Numbers = strategy, s = rescan, m = minuit1. |
-| Hesse                 | `ROOT.RooFit.Hesse(True)`                         | `nll.fitConfig().SetParabErrors(True)`                      | Run Hesse after Migrad for accurate covariance. |
-| HesseStrategy         | n/a                                                | `nll.fitConfigOptions().SetValue("HesseStrategy", -1)`      | Starting Hesse strategy. -1 = first in HesseStrategySequence. |
-| HesseStrategySequence | n/a                                                | `nll.fitConfigOptions().SetValue("HesseStrategySequence", "23")` | Retry sequence for Hesse algorithm. |
+| Setting               | NLL option                                     | Post-construction                                                | Description                                                                          |
+| --------------------- | ---------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Tolerance             | `XRF.xRooFit.Tolerance(0.01)`                  | `nll.fitConfig().MinimizerOptions().SetTolerance(0.01)`          | Tolerance = 1000 × max EDM. Default 0.01 → max EDM of 1e-5. **Do not set above 10.** |
+| Strategy              | `ROOT.RooFit.Strategy(-1)`                     | `nll.fitConfig().MinimizerOptions().SetStrategy(-1)`             | Starting Minuit strategy. -1 = use first in StrategySequence.                        |
+| StrategySequence      | `XRF.xRooFit.StrategySequence("0s01s12s2s3m")` | `nll.fitConfigOptions().SetValue("StrategySequence", ...)`       | Retry sequence on failure. Numbers = strategy, s = rescan, m = minuit1.              |
+| Hesse                 | `ROOT.RooFit.Hesse(True)`                      | `nll.fitConfig().SetParabErrors(True)`                           | Run Hesse after Migrad for accurate covariance.                                      |
+| HesseStrategy         | n/a                                            | `nll.fitConfigOptions().SetValue("HesseStrategy", -1)`           | Starting Hesse strategy. -1 = first in HesseStrategySequence.                        |
+| HesseStrategySequence | n/a                                            | `nll.fitConfigOptions().SetValue("HesseStrategySequence", "23")` | Retry sequence for Hesse algorithm.                                                  |
 
 ### Strategy Details
 
-| Strategy | Method                                    | Speed   |
-| -------- | ----------------------------------------- | ------- |
-| 0        | Iterative Hessian approximation           | Fastest |
-| 1        | Not advised as starting strategy          |         |
-| 2        | Hesse with forward finite-difference      | Slower  |
-| 3        | Hesse with central finite-difference      | 4× cost of strategy 2 |
+| Strategy | Method                               | Speed                 |
+| -------- | ------------------------------------ | --------------------- |
+| 0        | Iterative Hessian approximation      | Fastest               |
+| 1        | Not advised as starting strategy     |                       |
+| 2        | Hesse with forward finite-difference | Slower                |
+| 3        | Hesse with central finite-difference | 4× cost of strategy 2 |
 
-**General approach**: start with low strategy, increase tolerance until
-fits converge, then increase strategy if the post-Hesse EDM exceeds the
-tolerance threshold.
+**General approach**: start with low strategy, increase tolerance until fits
+converge, then increase strategy if the post-Hesse EDM exceeds the tolerance
+threshold.
 
 ## Correlation Matrix
 
@@ -40,17 +40,16 @@ fr.Draw("CORR10 COLZ TEXT")    # top-10 off-diagonal correlations
 ```
 
 Correlations above ~80% indicate potentially degenerate parameters where
-different points in parameter space produce nearly identical model
-predictions. The covariance matrix (and symmetric uncertainties) cannot
-be trusted when the likelihood minimum is poorly defined due to
-degeneracy.
+different points in parameter space produce nearly identical model predictions.
+The covariance matrix (and symmetric uncertainties) cannot be trusted when the
+likelihood minimum is poorly defined due to degeneracy.
 
 ## Impact and Ranking
 
-Impact measures how much a parameter of interest μ shifts when a
-nuisance parameter ν is moved by its uncertainty and held constant:
+Impact measures how much a parameter of interest μ shifts when a nuisance
+parameter ν is moved by its uncertainty and held constant:
 
-Δ_{ν±}μ = μ̂̂(ν=ν̂+Δ±ν) − μ̂
+Δ\_{ν±}μ = μ̂̂(ν=ν̂+Δ±ν) − μ̂
 
 ### Computing Impact
 
@@ -66,20 +65,19 @@ fr.impact("mu_sig", "alpha_JES", up=True, prefit=True, approx=True)
 
 ### Relationship to Correlation
 
-Impact ranking is approximately the same as ranking correlation
-coefficients:
+Impact ranking is approximately the same as ranking correlation coefficients:
 
-Δ_{ν±}μ ≈ cov(μ,ν) / (±Δν) = corr(μ,ν) · (±Δμ)
+Δ\_{ν±}μ ≈ cov(μ,ν) / (±Δν) = corr(μ,ν) · (±Δμ)
 
 ## Conditional Uncertainties and Uncertainty Breakdowns
 
-The conditional uncertainty on μ when holding ν constant at its post-fit
-value is:
+The conditional uncertainty on μ when holding ν constant at its post-fit value
+is:
 
 Δμ(ν=ν̂) ≈ √(cov(μ,μ) − cov(μ,ν)²/cov(ν,ν))
 
-For multiple conditioned parameters, use the Schur complement of the
-covariance matrix block decomposition.
+For multiple conditioned parameters, use the Schur complement of the covariance
+matrix block decomposition.
 
 ### Computing Conditional Uncertainties
 
@@ -109,8 +107,8 @@ mcStatErr = ROOT.TMath.Sqrt(statAndMCStatErr**2 - statErr**2)
 
 ### Shifted Global Observables (Shifted GO) Method
 
-A newer (2025) technique for systematic uncertainty breakdowns using
-quadrature sum of covariance-approximated prefit impacts:
+A newer (2025) technique for systematic uncertainty breakdowns using quadrature
+sum of covariance-approximated prefit impacts:
 
 ```python
 systErr = ROOT.TMath.Sqrt(
@@ -124,8 +122,8 @@ systErr = ROOT.TMath.Sqrt(
 
 ## Conditional Fits
 
-Perform conditional fits (holding parameters at specific values) using
-the fit result:
+Perform conditional fits (holding parameters at specific values) using the fit
+result:
 
 ```python
 fr = nll.minimize()
@@ -151,9 +149,8 @@ g.Draw("ALP")
 
 ## Goodness of Fit (Extended)
 
-xRooFit uses the **saturated model** to compute goodness-of-fit
-p-values. The saturated model likelihood ratio test statistic is assumed
-χ²-distributed.
+xRooFit uses the **saturated model** to compute goodness-of-fit p-values. The
+saturated model likelihood ratio test statistic is assumed χ²-distributed.
 
 ### Main-Term Only (Recommended for Observed Data)
 
@@ -166,9 +163,8 @@ nll.mainTermPgof()          # p-value
 
 ### Including Constraint Term (Valid for Toys Only)
 
-The constraint term's global observable nominal values bias the p-value
-towards larger values for observed data. Use this version only for toy
-datasets.
+The constraint term's global observable nominal values bias the p-value towards
+larger values for observed data. Use this version only for toy datasets.
 
 ```python
 nll.getVal()          # full NLL

--- a/plugins/atlas/skills/xroofit/references/hypothesis-testing.md
+++ b/plugins/atlas/skills/xroofit/references/hypothesis-testing.md
@@ -2,9 +2,9 @@
 
 ## Hypothesis Spaces
 
-A **hypothesis space** (hypoSpace) is defined by selecting which
-parameters define the hypotheses to test. Assign parameters to axes of
-the hypoSpace (one parameter per axis) or fix them to specific values.
+A **hypothesis space** (hypoSpace) is defined by selecting which parameters
+define the hypotheses to test. Assign parameters to axes of the hypoSpace (one
+parameter per axis) or fix them to specific values.
 
 Examples:
 
@@ -19,13 +19,13 @@ t_μ = −2 ln(L(μ,ν̂̂,θ) / L(μ̂,ν̂,θ))
 
 ### Available Test Statistics
 
-| Name       | Symbol     | Use case        | Description |
-| ---------- | ---------- | --------------- | ----------- |
-| `tmu`      | t_μ        | Two-sided       | Full PLR, no capping |
-| `qmu`      | q_μ        | Upper limits    | One-sided capped-above: 0 if μ̂ ≥ μ |
-| `qmutilde` | q̃_μ       | Upper limits    | One-sided capped-above + lower-bounded: accounts for physical boundary μ_L |
-| `q0`       | q₀         | Discovery       | One-sided capped-below: 0 if μ̂ ≤ 0 |
-| `u0`       | u₀         | Discovery       | Uncapped: −t₀ if μ̂ ≤ 0, else t₀ |
+| Name       | Symbol | Use case     | Description                                                                |
+| ---------- | ------ | ------------ | -------------------------------------------------------------------------- |
+| `tmu`      | t_μ    | Two-sided    | Full PLR, no capping                                                       |
+| `qmu`      | q_μ    | Upper limits | One-sided capped-above: 0 if μ̂ ≥ μ                                         |
+| `qmutilde` | q̃_μ    | Upper limits | One-sided capped-above + lower-bounded: accounts for physical boundary μ_L |
+| `q0`       | q₀     | Discovery    | One-sided capped-below: 0 if μ̂ ≤ 0                                         |
+| `u0`       | u₀     | Discovery    | Uncapped: −t₀ if μ̂ ≤ 0, else t₀                                            |
 
 `qmutilde` is the default for upper limits. `u0` has become popular for
 discovery in recent years.
@@ -35,29 +35,29 @@ discovery in recent years.
 Each scanned point in the hypoSpace is a **hypoPoint** with computable
 quantities:
 
-| Method (results have `.value()` and `.error()`) | Description |
-| ------------------------------------------------ | ----------- |
-| `pNull_asymp()`                                  | Observed p_null from asymptotic formulae |
-| `pNull_asymp(n)`                                 | n-sigma expected p_null |
-| `pAlt_asymp()`                                   | Observed p_alt from asymptotic formulae |
-| `pAlt_asymp(n)`                                  | n-sigma expected p_alt (= Φ(n) by construction) |
-| `pCLs_asymp()`                                   | pNull/pAlt (observed) |
-| `pCLs_asymp(n)`                                  | pNull(n)/pAlt(n) (n-sigma expected) |
-| `ts_asymp()`                                     | Observed test statistic value |
-| `ts_asymp(n)`                                    | n-sigma Asimov test statistic value |
+| Method (results have `.value()` and `.error()`) | Description                                     |
+| ----------------------------------------------- | ----------------------------------------------- |
+| `pNull_asymp()`                                 | Observed p_null from asymptotic formulae        |
+| `pNull_asymp(n)`                                | n-sigma expected p_null                         |
+| `pAlt_asymp()`                                  | Observed p_alt from asymptotic formulae         |
+| `pAlt_asymp(n)`                                 | n-sigma expected p_alt (= Φ(n) by construction) |
+| `pCLs_asymp()`                                  | pNull/pAlt (observed)                           |
+| `pCLs_asymp(n)`                                 | pNull(n)/pAlt(n) (n-sigma expected)             |
+| `ts_asymp()`                                    | Observed test statistic value                   |
+| `ts_asymp(n)`                                   | n-sigma Asimov test statistic value             |
 
 Replace `_asymp` with `_toys` for toy-based values.
 
 ## HypoPoint Fits
 
-| Method              | Description |
-| ------------------- | ----------- |
-| `ufit()`            | Unconditional fit to observed data (PLR denominator) |
-| `cfit_null()`       | Conditional fit with POI at null hypothesis values (PLR numerator) |
-| `cfit_alt()`        | Conditional fit with POI at alt hypothesis values (needed for Asimov generation) |
-| `cfit_lbound()`     | Conditional fit with POI at lower bound μ_L (needed for q̃_μ if μ̂ < μ_L) |
-| `asimov().ufit()`   | Unconditional fit to Asimov dataset (for asymptotic formulae) |
-| `asimov().cfit_null()` | Null conditional fit to Asimov dataset |
+| Method                 | Description                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `ufit()`               | Unconditional fit to observed data (PLR denominator)                             |
+| `cfit_null()`          | Conditional fit with POI at null hypothesis values (PLR numerator)               |
+| `cfit_alt()`           | Conditional fit with POI at alt hypothesis values (needed for Asimov generation) |
+| `cfit_lbound()`        | Conditional fit with POI at lower bound μ*L (needed for q̃*μ if μ̂ < μ_L)          |
+| `asimov().ufit()`      | Unconditional fit to Asimov dataset (for asymptotic formulae)                    |
+| `asimov().cfit_null()` | Null conditional fit to Asimov dataset                                           |
 
 ## Full Verbose Limit-Setting Example
 
@@ -109,13 +109,13 @@ w.Browse()  # hypoSpace appears under "scans" folder
 
 ### Key Parameters
 
-- **`channels`**: comma-separated channel list; use `reduced()` to
-  exclude validation regions
-- **`nSigmas`**: `float('nan')` requests the observed limit; integers
-  request expected ±N sigma limits
-- **`limits()`**: returns `std::map` keyed by `"-2"`, `"-1"`, `"0"`,
-  `"1"`, `"2"` (expected) and `"obs"` (observed); each value has
-  `.value()` and `.error()`
+- **`channels`**: comma-separated channel list; use `reduced()` to exclude
+  validation regions
+- **`nSigmas`**: `float('nan')` requests the observed limit; integers request
+  expected ±N sigma limits
+- **`limits()`**: returns `std::map` keyed by `"-2"`, `"-1"`, `"0"`, `"1"`,
+  `"2"` (expected) and `"obs"` (observed); each value has `.value()` and
+  `.error()`
 
 ## Toy-Based Limits
 
@@ -135,25 +135,23 @@ hs.Print()    # list hypoPoints
 hs[4].Draw()  # draw test statistic distribution for 5th point
 ```
 
-For capped test statistics (all except `u0`), check for toys with
-ts < 0. These indicate unconditional fits that did not converge on the
-true minimum — often caused by setting tolerance too high.
+For capped test statistics (all except `u0`), check for toys with ts < 0. These
+indicate unconditional fits that did not converge on the true minimum — often
+caused by setting tolerance too high.
 
 ## Limit-Setting Troubleshooting
 
 ### Common Failure Modes
 
-1. **Scan range too large**: hypoPoints far from the data cause fits to
-   fail (status=1, covariance forced positive-definite). Narrow the scan
-   range.
+1. **Scan range too large**: hypoPoints far from the data cause fits to fail
+   (status=1, covariance forced positive-definite). Narrow the scan range.
 
-2. **Problematic nuisance parameter**: use `constPars` to hold groups
-   constant and isolate which NP causes failures. Use
-   `w.pars().Print()` and `w.floats().Print()` to inspect.
+2. **Problematic nuisance parameter**: use `constPars` to hold groups constant
+   and isolate which NP causes failures. Use `w.pars().Print()` and
+   `w.floats().Print()` to inspect.
 
-3. **status=3 (EDM above threshold)**: increase Tolerance (up to ~10).
-   If post-Hesse EDM warnings appear with strategy 0, increase to
-   strategy 2.
+3. **status=3 (EDM above threshold)**: increase Tolerance (up to ~10). If
+   post-Hesse EDM warnings appear with strategy 0, increase to strategy 2.
 
 4. **NaN limits**: print the hypoSpace (`hs.Print()`) to inspect which
    hypoPoints had non-zero status codes.
@@ -165,8 +163,8 @@ Before running limits, answer these questions:
 - What are the hypoSpace parameters and their values/axes?
 - What hypoPoints are being tested?
 - What p-value type: pNull (CLs+b) or pCLs (CLs)?
-- How are p-values interpolated across the hypoSpace? (xRooFit uses
-  log-linear along POI axis)
+- How are p-values interpolated across the hypoSpace? (xRooFit uses log-linear
+  along POI axis)
 - What PLR test statistic variant?
 - Toys or asymptotic formulae?
 - What is the uncertainty on each p-value?

--- a/plugins/atlas/skills/xroofit/references/hypothesis-testing.md
+++ b/plugins/atlas/skills/xroofit/references/hypothesis-testing.md
@@ -1,0 +1,190 @@
+# Advanced Hypothesis Testing
+
+## Hypothesis Spaces
+
+A **hypothesis space** (hypoSpace) is defined by selecting which
+parameters define the hypotheses to test. Assign parameters to axes of
+the hypoSpace (one parameter per axis) or fix them to specific values.
+
+Examples:
+
+- Higgs search: mass parameter on x-axis, signal strength on y-axis
+- SUSY search: two mass parameters on axes, signal strength fixed to 1
+
+## Test Statistics
+
+All test statistics are variants of the profile likelihood ratio:
+
+t_μ = −2 ln(L(μ,ν̂̂,θ) / L(μ̂,ν̂,θ))
+
+### Available Test Statistics
+
+| Name       | Symbol     | Use case        | Description |
+| ---------- | ---------- | --------------- | ----------- |
+| `tmu`      | t_μ        | Two-sided       | Full PLR, no capping |
+| `qmu`      | q_μ        | Upper limits    | One-sided capped-above: 0 if μ̂ ≥ μ |
+| `qmutilde` | q̃_μ       | Upper limits    | One-sided capped-above + lower-bounded: accounts for physical boundary μ_L |
+| `q0`       | q₀         | Discovery       | One-sided capped-below: 0 if μ̂ ≤ 0 |
+| `u0`       | u₀         | Discovery       | Uncapped: −t₀ if μ̂ ≤ 0, else t₀ |
+
+`qmutilde` is the default for upper limits. `u0` has become popular for
+discovery in recent years.
+
+## HypoPoint Quantities
+
+Each scanned point in the hypoSpace is a **hypoPoint** with computable
+quantities:
+
+| Method (results have `.value()` and `.error()`) | Description |
+| ------------------------------------------------ | ----------- |
+| `pNull_asymp()`                                  | Observed p_null from asymptotic formulae |
+| `pNull_asymp(n)`                                 | n-sigma expected p_null |
+| `pAlt_asymp()`                                   | Observed p_alt from asymptotic formulae |
+| `pAlt_asymp(n)`                                  | n-sigma expected p_alt (= Φ(n) by construction) |
+| `pCLs_asymp()`                                   | pNull/pAlt (observed) |
+| `pCLs_asymp(n)`                                  | pNull(n)/pAlt(n) (n-sigma expected) |
+| `ts_asymp()`                                     | Observed test statistic value |
+| `ts_asymp(n)`                                    | n-sigma Asimov test statistic value |
+
+Replace `_asymp` with `_toys` for toy-based values.
+
+## HypoPoint Fits
+
+| Method              | Description |
+| ------------------- | ----------- |
+| `ufit()`            | Unconditional fit to observed data (PLR denominator) |
+| `cfit_null()`       | Conditional fit with POI at null hypothesis values (PLR numerator) |
+| `cfit_alt()`        | Conditional fit with POI at alt hypothesis values (needed for Asimov generation) |
+| `cfit_lbound()`     | Conditional fit with POI at lower bound μ_L (needed for q̃_μ if μ̂ < μ_L) |
+| `asimov().ufit()`   | Unconditional fit to Asimov dataset (for asymptotic formulae) |
+| `asimov().cfit_null()` | Null conditional fit to Asimov dataset |
+
+## Full Verbose Limit-Setting Example
+
+```python
+import ROOT
+XRF = ROOT  # or: XRF = ROOT.Experimental.XRooFit
+
+fileName  = "path/to/workspace.root"
+pdfName   = "simPdf"
+channels  = "*"         # comma-separated; exclude VRs
+dsName    = "obsData"   # "" for Asimov
+poiName   = ""          # "" to auto-infer
+asimovVal = 0           # POI value for Asimov dataset
+scanMin   = 0
+scanMax   = 10
+scanN     = 0           # 0 = auto-scan
+scanType  = "cls visualize"
+constPars = ""          # "*" for stat-only
+tsType    = XRF.xRooFit.TestStatistic.qmutilde
+nSigmas   = [0, 1, 2, -1, -2, float('nan')]  # NaN = observed
+
+w = XRF.xRooNode(fileName)
+if poiName == "":
+    poiName = w.poi()[0].GetName()
+if constPars != "":
+    w.pars().reduced(constPars).setAttribAll("Constant")
+w.pars()[poiName].setVal(asimovVal)
+
+hs = w[pdfName].reduced(channels).nll(dsName).hypoSpace(
+    poiName, tsType
+)
+hs.scan(scanType, scanN, scanMin, scanMax, nSigmas)
+limits = hs.limits()
+
+print(limits)
+hasNaN = False
+for nSigma, lim in dict(limits).items():
+    if ROOT.TMath.IsNaN(lim.value()):
+        hasNaN = True
+if hasNaN:
+    hs.Print()  # inspect status codes
+
+# Save result to workspace
+outFile = "result.root"
+w.Add(hs.result())
+w.SaveAs(outFile)
+w.Browse()  # hypoSpace appears under "scans" folder
+```
+
+### Key Parameters
+
+- **`channels`**: comma-separated channel list; use `reduced()` to
+  exclude validation regions
+- **`nSigmas`**: `float('nan')` requests the observed limit; integers
+  request expected ±N sigma limits
+- **`limits()`**: returns `std::map` keyed by `"-2"`, `"-1"`, `"0"`,
+  `"1"`, `"2"` (expected) and `"obs"` (observed); each value has
+  `.value()` and `.error()`
+
+## Toy-Based Limits
+
+Replace `scanType` to use toys instead of asymptotic formulae:
+
+```python
+scanType = "cls toys=1000.1"  # 1000 null + 100 alt toys per point
+scanType = "cls toys=1000"    # 1000 null + 1000 alt toys per point
+scanType = "cls toys"         # auto: 100-toy blocks until 2σ
+                              # confidence on pCLs, max 10k
+```
+
+### Inspecting Toy Distributions
+
+```python
+hs.Print()    # list hypoPoints
+hs[4].Draw()  # draw test statistic distribution for 5th point
+```
+
+For capped test statistics (all except `u0`), check for toys with
+ts < 0. These indicate unconditional fits that did not converge on the
+true minimum — often caused by setting tolerance too high.
+
+## Limit-Setting Troubleshooting
+
+### Common Failure Modes
+
+1. **Scan range too large**: hypoPoints far from the data cause fits to
+   fail (status=1, covariance forced positive-definite). Narrow the scan
+   range.
+
+2. **Problematic nuisance parameter**: use `constPars` to hold groups
+   constant and isolate which NP causes failures. Use
+   `w.pars().Print()` and `w.floats().Print()` to inspect.
+
+3. **status=3 (EDM above threshold)**: increase Tolerance (up to ~10).
+   If post-Hesse EDM warnings appear with strategy 0, increase to
+   strategy 2.
+
+4. **NaN limits**: print the hypoSpace (`hs.Print()`) to inspect which
+   hypoPoints had non-zero status codes.
+
+### Limit-Setting Checklist
+
+Before running limits, answer these questions:
+
+- What are the hypoSpace parameters and their values/axes?
+- What hypoPoints are being tested?
+- What p-value type: pNull (CLs+b) or pCLs (CLs)?
+- How are p-values interpolated across the hypoSpace? (xRooFit uses
+  log-linear along POI axis)
+- What PLR test statistic variant?
+- Toys or asymptotic formulae?
+- What is the uncertainty on each p-value?
+- Did any fits fail?
+
+## Discovery Significance
+
+Scan a single point at the background-only hypothesis:
+
+```python
+hs = nll.hypoSpace("mu_sig", XRF.xRooFit.TestStatistic.u0)
+hs.scan("pnull", 1, 0, 0)  # single point at mu=0
+
+print("Observed p0:", hs[0].pNull_asymp())
+print("Expected p0:", hs[0].pNull_asymp(0))   # under mu=1
+print("Expected +1σ:", hs[0].pNull_asymp(1))
+print("Expected -1σ:", hs[0].pNull_asymp(-1))
+
+# Convert to significance
+sig = ROOT.Math.gaussian_quantile_c(hs[0].pNull_asymp().value(), 1)
+```

--- a/plugins/atlas/skills/xroofit/references/workspace-building.md
+++ b/plugins/atlas/skills/xroofit/references/workspace-building.md
@@ -1,0 +1,154 @@
+# Advanced Workspace Building
+
+## Declaring Observables with SetXaxis
+
+Instead of using a histogram to declare a channel's observable, use
+`SetXaxis` directly:
+
+```python
+w["pdfs/simPdf/SR"].SetXaxis("obsName", "obs title", nBins, low, high)
+w["pdfs/simPdf/SR/samples"].Add("bkg")
+```
+
+Both approaches create an initial `SimpleDensity` factor for the sample.
+
+## Factor Types
+
+Factors are the building blocks of samples. Two categories:
+observable-dependent and observable-independent. Conventionally,
+observable-independent factors become the **coefficients** of a sample
+(`coefs()`), while observable-dependent factors remain inside the sample
+itself.
+
+### Basic Factor Types
+
+| Type    | Obs-dependent | Parameterized | RooFit class          | Description                               |
+| ------- | ------------- | ------------- | --------------------- | ----------------------------------------- |
+| Const   | No            | No            | `RooConstVar`         | Pre-specified constant                    |
+| Norm    | No            | Yes           | `RooRealVar`          | Floatable normalization parameter         |
+| Simple  | Yes           | No            | `RooHistFunc`         | Histogram of bin yields                   |
+| Density | Yes           | No            | `RooBinWidthFunction` | Special Simple factor where value = 1/binWidth |
+| Shape   | Yes           | Yes           | `ParamHistFunc`       | Per-bin individual norm factors            |
+
+### Varied Factor Types
+
+Factors can be made parameter-dependent by defining **variations** at
+points in a variation space with interpolation/extrapolation rules.
+
+| Type    | Description                                         | RooFit class                          |
+| ------- | --------------------------------------------------- | ------------------------------------- |
+| Varied  | General parameterized factor with variations        | `PiecewiseInterpolation`              |
+| Overall | Varied factor where variations are const factors    | `FlexibleInterpVar` or `PiecewiseInterpolation` |
+| Histo   | Varied factor where variations are simple factors   | `PiecewiseInterpolation`              |
+| Func    | Generic parametric function                         | `RooFormulaVar`                       |
+
+### Creating and Multiplying Factors
+
+```python
+# Observable-dependent factor
+w["pdfs/simPdf/SR/samples/bkg"].Multiply("myFactor", "shape")
+
+# Observable-independent (coefficient)
+w["pdfs/simPdf/SR/samples/bkg"].coefs().Multiply("mu_bkg", "norm")
+```
+
+If a factor with the same name already exists in the workspace, the type
+argument is ignored and the existing factor is reused. This enables
+factor sharing across samples and channels.
+
+## Interpolation and Extrapolation Codes
+
+Varied factors use an interpolation code to determine how the factor is
+computed between and beyond the defined variation points.
+
+For a varied factor with nominal variation f₀(x) and up/down variations
+f_{i+}(x)/f_{i−}(x) for parameter θᵢ:
+
+- **Additive** codes: f(x|θ) = f₀(x) + Σᵢ I(θᵢ; f_{i−}, f₀, f_{i+})
+- **Multiplicative** codes: f(x|θ) = f₀(x) · Πᵢ I(θᵢ; f_{i−}/f₀, 1,
+  f_{i+}/f₀)
+
+| Code | Name                                        | Recommended for       |
+| ---- | ------------------------------------------- | --------------------- |
+| 0    | Additive piecewise linear                   | **Not recommended** (derivative discontinuities) |
+| 1    | Multiplicative piecewise exponential        | **Not recommended**   |
+| 4    | Additive poly interp + linear extrap        | **Histo factors**     |
+| 5    | Multiplicative poly interp + exponential extrap | **Overall factors** (interpCode=4 in FlexibleInterpVar) |
+| 6    | Multiplicative poly interp + linear extrap  | Norm factors that must not have roots outside \|θ\|<1 |
+
+Codes 4 and 5 use a 6th-order polynomial in the \|θ\|<1 region, matched
+to 0th/1st/2nd derivatives at the boundaries.
+
+### Checking and Changing Interpolation Codes
+
+```python
+w["pdfs/simPdf/SR/samples/sampleName/sampleName"].printAllInterpCodes()
+w["pdfs/simPdf/SR/samples/sampleName/sampleName"].setAllInterpCodes(4)
+```
+
+## Factor vs Sys
+
+When any parameter of a parameter-dependent factor also has a
+**constraint term**, the word "factor" is replaced by "sys":
+
+- ShapeFactor → ShapeSys
+- NormFactor with constraint → NormSys (effectively)
+
+Promote a factor to a sys by adding a constraint:
+
+```python
+w["pdfs/simPdf"].pars()["npName"].Constrain("gaussian(0,1)")
+w["pdfs/simPdf"].pars()["npName"].Constrain("normal")  # alias
+```
+
+### Log-normal Constraints
+
+Replace the parameter with its exponentiated version, then apply a
+normal constraint:
+
+```python
+w["pdfs/simPdf"].pars()["npName"].Replace(
+    "expr::expo_npName('exp(npName)', npName)"
+)
+w["pdfs/simPdf"].pars()["npName"].Constrain("normal")
+```
+
+## MC Statistical Uncertainties
+
+When a histogram with non-zero bin errors is added as a sample, xRooFit
+automatically creates a **ShapeSys** with Poisson-constrained γ
+parameters for MC statistical uncertainties. This ShapeSys is nominally
+shared between all samples in the channel.
+
+### Controlling MC Stat Behavior
+
+- **Suppress**: zero out bin errors before adding the histogram
+- **Control prefix**: `hBkg.SetOption("statPrefix=stat_SR_bkg")` (default
+  prefix: `stat_<channelName>`)
+- **Separate per sample**: any sample with its own NormFactor should have
+  its own separate ShapeSys (or none) rather than sharing, because the
+  normalization factor is not accounted for in the Poisson constraint
+  calculation otherwise
+
+### Variation Histograms
+
+Variation histograms passed to `Vary()` **must have zero bin errors**.
+Non-zero bin errors on variations create "errors-on-errors" which are
+not fully supported.
+
+## Creating Datasets
+
+### From Histogram
+
+```python
+hData.SetName("obsData")
+w["pdfs/simPdf/channelName"].datasets().Add(hData)
+```
+
+### Bin-by-Bin
+
+```python
+w["pdfs/simPdf/channelName"].SetBinData(binNumber, value, "obsData")
+```
+
+The dataset name defaults to `"obsData"` if unspecified.

--- a/plugins/atlas/skills/xroofit/references/workspace-building.md
+++ b/plugins/atlas/skills/xroofit/references/workspace-building.md
@@ -2,8 +2,8 @@
 
 ## Declaring Observables with SetXaxis
 
-Instead of using a histogram to declare a channel's observable, use
-`SetXaxis` directly:
+Instead of using a histogram to declare a channel's observable, use `SetXaxis`
+directly:
 
 ```python
 w["pdfs/simPdf/SR"].SetXaxis("obsName", "obs title", nBins, low, high)
@@ -14,33 +14,32 @@ Both approaches create an initial `SimpleDensity` factor for the sample.
 
 ## Factor Types
 
-Factors are the building blocks of samples. Two categories:
-observable-dependent and observable-independent. Conventionally,
-observable-independent factors become the **coefficients** of a sample
-(`coefs()`), while observable-dependent factors remain inside the sample
-itself.
+Factors are the building blocks of samples. Two categories: observable-dependent
+and observable-independent. Conventionally, observable-independent factors
+become the **coefficients** of a sample (`coefs()`), while observable-dependent
+factors remain inside the sample itself.
 
 ### Basic Factor Types
 
-| Type    | Obs-dependent | Parameterized | RooFit class          | Description                               |
-| ------- | ------------- | ------------- | --------------------- | ----------------------------------------- |
-| Const   | No            | No            | `RooConstVar`         | Pre-specified constant                    |
-| Norm    | No            | Yes           | `RooRealVar`          | Floatable normalization parameter         |
-| Simple  | Yes           | No            | `RooHistFunc`         | Histogram of bin yields                   |
+| Type    | Obs-dependent | Parameterized | RooFit class          | Description                                    |
+| ------- | ------------- | ------------- | --------------------- | ---------------------------------------------- |
+| Const   | No            | No            | `RooConstVar`         | Pre-specified constant                         |
+| Norm    | No            | Yes           | `RooRealVar`          | Floatable normalization parameter              |
+| Simple  | Yes           | No            | `RooHistFunc`         | Histogram of bin yields                        |
 | Density | Yes           | No            | `RooBinWidthFunction` | Special Simple factor where value = 1/binWidth |
-| Shape   | Yes           | Yes           | `ParamHistFunc`       | Per-bin individual norm factors            |
+| Shape   | Yes           | Yes           | `ParamHistFunc`       | Per-bin individual norm factors                |
 
 ### Varied Factor Types
 
-Factors can be made parameter-dependent by defining **variations** at
-points in a variation space with interpolation/extrapolation rules.
+Factors can be made parameter-dependent by defining **variations** at points in
+a variation space with interpolation/extrapolation rules.
 
-| Type    | Description                                         | RooFit class                          |
-| ------- | --------------------------------------------------- | ------------------------------------- |
-| Varied  | General parameterized factor with variations        | `PiecewiseInterpolation`              |
-| Overall | Varied factor where variations are const factors    | `FlexibleInterpVar` or `PiecewiseInterpolation` |
-| Histo   | Varied factor where variations are simple factors   | `PiecewiseInterpolation`              |
-| Func    | Generic parametric function                         | `RooFormulaVar`                       |
+| Type    | Description                                       | RooFit class                                    |
+| ------- | ------------------------------------------------- | ----------------------------------------------- |
+| Varied  | General parameterized factor with variations      | `PiecewiseInterpolation`                        |
+| Overall | Varied factor where variations are const factors  | `FlexibleInterpVar` or `PiecewiseInterpolation` |
+| Histo   | Varied factor where variations are simple factors | `PiecewiseInterpolation`                        |
+| Func    | Generic parametric function                       | `RooFormulaVar`                                 |
 
 ### Creating and Multiplying Factors
 
@@ -53,31 +52,30 @@ w["pdfs/simPdf/SR/samples/bkg"].coefs().Multiply("mu_bkg", "norm")
 ```
 
 If a factor with the same name already exists in the workspace, the type
-argument is ignored and the existing factor is reused. This enables
-factor sharing across samples and channels.
+argument is ignored and the existing factor is reused. This enables factor
+sharing across samples and channels.
 
 ## Interpolation and Extrapolation Codes
 
-Varied factors use an interpolation code to determine how the factor is
-computed between and beyond the defined variation points.
+Varied factors use an interpolation code to determine how the factor is computed
+between and beyond the defined variation points.
 
 For a varied factor with nominal variation f₀(x) and up/down variations
-f_{i+}(x)/f_{i−}(x) for parameter θᵢ:
+f*{i+}(x)/f*{i−}(x) for parameter θᵢ:
 
-- **Additive** codes: f(x|θ) = f₀(x) + Σᵢ I(θᵢ; f_{i−}, f₀, f_{i+})
-- **Multiplicative** codes: f(x|θ) = f₀(x) · Πᵢ I(θᵢ; f_{i−}/f₀, 1,
-  f_{i+}/f₀)
+- **Additive** codes: f(x|θ) = f₀(x) + Σᵢ I(θᵢ; f*{i−}, f₀, f*{i+})
+- **Multiplicative** codes: f(x|θ) = f₀(x) · Πᵢ I(θᵢ; f*{i−}/f₀, 1, f*{i+}/f₀)
 
-| Code | Name                                        | Recommended for       |
-| ---- | ------------------------------------------- | --------------------- |
-| 0    | Additive piecewise linear                   | **Not recommended** (derivative discontinuities) |
-| 1    | Multiplicative piecewise exponential        | **Not recommended**   |
-| 4    | Additive poly interp + linear extrap        | **Histo factors**     |
+| Code | Name                                            | Recommended for                                         |
+| ---- | ----------------------------------------------- | ------------------------------------------------------- |
+| 0    | Additive piecewise linear                       | **Not recommended** (derivative discontinuities)        |
+| 1    | Multiplicative piecewise exponential            | **Not recommended**                                     |
+| 4    | Additive poly interp + linear extrap            | **Histo factors**                                       |
 | 5    | Multiplicative poly interp + exponential extrap | **Overall factors** (interpCode=4 in FlexibleInterpVar) |
-| 6    | Multiplicative poly interp + linear extrap  | Norm factors that must not have roots outside \|θ\|<1 |
+| 6    | Multiplicative poly interp + linear extrap      | Norm factors that must not have roots outside \|θ\|<1   |
 
-Codes 4 and 5 use a 6th-order polynomial in the \|θ\|<1 region, matched
-to 0th/1st/2nd derivatives at the boundaries.
+Codes 4 and 5 use a 6th-order polynomial in the \|θ\|<1 region, matched to
+0th/1st/2nd derivatives at the boundaries.
 
 ### Checking and Changing Interpolation Codes
 
@@ -88,8 +86,8 @@ w["pdfs/simPdf/SR/samples/sampleName/sampleName"].setAllInterpCodes(4)
 
 ## Factor vs Sys
 
-When any parameter of a parameter-dependent factor also has a
-**constraint term**, the word "factor" is replaced by "sys":
+When any parameter of a parameter-dependent factor also has a **constraint
+term**, the word "factor" is replaced by "sys":
 
 - ShapeFactor → ShapeSys
 - NormFactor with constraint → NormSys (effectively)
@@ -103,8 +101,8 @@ w["pdfs/simPdf"].pars()["npName"].Constrain("normal")  # alias
 
 ### Log-normal Constraints
 
-Replace the parameter with its exponentiated version, then apply a
-normal constraint:
+Replace the parameter with its exponentiated version, then apply a normal
+constraint:
 
 ```python
 w["pdfs/simPdf"].pars()["npName"].Replace(
@@ -116,25 +114,24 @@ w["pdfs/simPdf"].pars()["npName"].Constrain("normal")
 ## MC Statistical Uncertainties
 
 When a histogram with non-zero bin errors is added as a sample, xRooFit
-automatically creates a **ShapeSys** with Poisson-constrained γ
-parameters for MC statistical uncertainties. This ShapeSys is nominally
-shared between all samples in the channel.
+automatically creates a **ShapeSys** with Poisson-constrained γ parameters for
+MC statistical uncertainties. This ShapeSys is nominally shared between all
+samples in the channel.
 
 ### Controlling MC Stat Behavior
 
 - **Suppress**: zero out bin errors before adding the histogram
 - **Control prefix**: `hBkg.SetOption("statPrefix=stat_SR_bkg")` (default
   prefix: `stat_<channelName>`)
-- **Separate per sample**: any sample with its own NormFactor should have
-  its own separate ShapeSys (or none) rather than sharing, because the
-  normalization factor is not accounted for in the Poisson constraint
-  calculation otherwise
+- **Separate per sample**: any sample with its own NormFactor should have its
+  own separate ShapeSys (or none) rather than sharing, because the normalization
+  factor is not accounted for in the Poisson constraint calculation otherwise
 
 ### Variation Histograms
 
-Variation histograms passed to `Vary()` **must have zero bin errors**.
-Non-zero bin errors on variations create "errors-on-errors" which are
-not fully supported.
+Variation histograms passed to `Vary()` **must have zero bin errors**. Non-zero
+bin errors on variations create "errors-on-errors" which are not fully
+supported.
 
 ## Creating Datasets
 

--- a/scripts/lint_skills.py
+++ b/scripts/lint_skills.py
@@ -26,13 +26,13 @@ ROOT = Path(__file__).resolve().parent.parent
 ORDERED_PAIRS: list[tuple[str, str]] = [
     ("Overview", "When to Use"),
     ("When to Use", "Canonical Patterns"),
+    ("Canonical Patterns", "Worked Example"),
     ("Canonical Patterns", "Gotchas"),
     ("Canonical Patterns", "Interop"),
+    ("Worked Example", "Troubleshooting"),
+    ("Troubleshooting", "Gotchas"),
     ("Gotchas", "Interop"),
     ("Interop", "Docs"),
-    ("Worked Example", "Troubleshooting"),
-    ("Interop", "Additional Resources"),
-    ("Additional Resources", "Docs"),
 ]
 
 # Sections that MUST be present in any standard skill.
@@ -40,7 +40,10 @@ ORDERED_PAIRS: list[tuple[str, str]] = [
 REQUIRED_IN_STANDARD_SKILL: list[str] = [
     "Overview",
     "When to Use",
+    "Key Concepts",
     "Canonical Patterns",
+    "Gotchas",
+    "Interop",
     "Docs",
 ]
 
@@ -68,6 +71,13 @@ def _find_index(headings: list[str], name: str) -> int | None:
     return None
 
 
+def _docs_section_content(path: Path) -> str:
+    """Return the text of the ## Docs section (empty string if absent)."""
+    text = path.read_text(encoding="utf-8")
+    m = re.search(r"^## Docs\s*\n(.*?)(?=^## |\Z)", text, re.MULTILINE | re.DOTALL)
+    return m.group(1) if m else ""
+
+
 def check_skill(path: Path) -> list[str]:
     """Return a list of human-readable error strings for this SKILL.md."""
     headings = _section_headings(path)
@@ -91,6 +101,18 @@ def check_skill(path: Path) -> list[str]:
                 f"section order: '## {headings[idx_a]}' (pos {idx_a + 1})"
                 f" must come before '## {headings[idx_b]}' (pos {idx_b + 1})"
             )
+
+    # Docs must be the last top-level section
+    idx_docs = _find_index(headings, "Docs")
+    if idx_docs is not None and idx_docs != len(headings) - 1:
+        errors.append(
+            f"'## Docs' must be the last section (found at pos {idx_docs + 1}"
+            f" of {len(headings)})"
+        )
+
+    # Docs must contain at least one https?:// URL
+    if idx_docs is not None and not re.search(r"https?://", _docs_section_content(path)):
+        errors.append("'## Docs' section contains no URL (https?://)")
 
     return errors
 

--- a/scripts/lint_skills.py
+++ b/scripts/lint_skills.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Lint SKILL.md files for section ordering and required sections.
+
+Only checks skills that follow the standard structure (i.e. have a
+'## Canonical Patterns' section). Custom-format skills such as uchicago-af
+or histfitter are skipped.
+
+Exit code 0 if all checks pass, 1 if any errors are found.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Canonical ordering rules
+#
+# These are PAIRS (A, B) meaning: if both A and B are present in a skill,
+# A must appear before B. Derived from universally consistent ordering
+# observed across all skills in the repo.
+# ---------------------------------------------------------------------------
+
+ORDERED_PAIRS: list[tuple[str, str]] = [
+    ("Overview", "When to Use"),
+    ("When to Use", "Canonical Patterns"),
+    ("Canonical Patterns", "Gotchas"),
+    ("Canonical Patterns", "Interop"),
+    ("Gotchas", "Interop"),
+    ("Interop", "Docs"),
+    ("Worked Example", "Troubleshooting"),
+    ("Interop", "Additional Resources"),
+    ("Additional Resources", "Docs"),
+]
+
+# Sections that MUST be present in any standard skill.
+# "Standard" means the skill has a '## Canonical Patterns' section.
+REQUIRED_IN_STANDARD_SKILL: list[str] = [
+    "Overview",
+    "When to Use",
+    "Canonical Patterns",
+    "Docs",
+]
+
+
+def _section_headings(path: Path) -> list[str]:
+    """Return all top-level (##) headings in order."""
+    text = path.read_text(encoding="utf-8")
+    return re.findall(r"^## (.+)$", text, re.MULTILINE)
+
+
+def _heading_matches(heading: str, name: str) -> bool:
+    """True if a heading equals name or starts with 'name:' / 'name '."""
+    return (
+        heading == name
+        or heading.startswith(f"{name}:")
+        or heading.startswith(f"{name} ")
+    )
+
+
+def _find_index(headings: list[str], name: str) -> int | None:
+    """Return the index of the first heading matching name, or None."""
+    for i, h in enumerate(headings):
+        if _heading_matches(h, name):
+            return i
+    return None
+
+
+def check_skill(path: Path) -> list[str]:
+    """Return a list of human-readable error strings for this SKILL.md."""
+    headings = _section_headings(path)
+    errors: list[str] = []
+
+    # Skip non-standard skills (no Canonical Patterns section)
+    if _find_index(headings, "Canonical Patterns") is None:
+        return []
+
+    # Required sections
+    for req in REQUIRED_IN_STANDARD_SKILL:
+        if _find_index(headings, req) is None:
+            errors.append(f"missing required section '## {req}'")
+
+    # Ordering pairs
+    for a, b in ORDERED_PAIRS:
+        idx_a = _find_index(headings, a)
+        idx_b = _find_index(headings, b)
+        if idx_a is not None and idx_b is not None and idx_a > idx_b:
+            errors.append(
+                f"section order: '## {headings[idx_a]}' (pos {idx_a + 1})"
+                f" must come before '## {headings[idx_b]}' (pos {idx_b + 1})"
+            )
+
+    return errors
+
+
+def main() -> None:
+    skill_files = sorted(ROOT.glob("plugins/*/skills/*/SKILL.md"))
+    failures: dict[Path, list[str]] = {}
+
+    for path in skill_files:
+        errs = check_skill(path)
+        if errs:
+            failures[path] = errs
+
+    if failures:
+        for path, errs in failures.items():
+            rel = path.relative_to(ROOT)
+            for err in errs:
+                print(f"{rel}: {err}")
+        print(f"\n{len(failures)} skill(s) failed.", file=sys.stderr)
+        sys.exit(1)
+
+    checked = sum(
+        1
+        for p in skill_files
+        if _find_index(_section_headings(p), "Canonical Patterns") is not None
+    )
+    skipped = len(skill_files) - checked
+    print(f"OK: {checked} standard skill(s) checked, {skipped} non-standard skipped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Sync README.md Plugins and Repository Layout sections from the filesystem.
+
+Usage:
+    python scripts/sync_skills.py           # update README in-place
+    python scripts/sync_skills.py --check   # exit 1 if README is out of date
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+README = ROOT / "README.md"
+MARKETPLACE_JSON = ROOT / ".claude-plugin" / "marketplace.json"
+
+START_MARKER = "<!-- UPDATE:START -->"
+END_MARKER = "<!-- UPDATE:END -->"
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(path: Path) -> dict[str, str]:
+    """Extract name and description from YAML frontmatter (no external deps)."""
+    text = path.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return {}
+    fm = m.group(1)
+    result: dict[str, str] = {}
+
+    name_m = re.search(r"^name:\s*(.+)$", fm, re.MULTILINE)
+    if name_m:
+        result["name"] = name_m.group(1).strip()
+
+    def _read_field(field: str) -> str | None:
+        """Read any YAML scalar form: >- block, inline, or wrapped continuation."""
+        # Explicit block scalar (>- or >)
+        block = re.search(
+            rf"^{field}:\s*(?:>-|>)\s*\n((?:[ \t]+\S[^\n]*\n?)+)",
+            fm,
+            re.MULTILINE,
+        )
+        if block:
+            return " ".join(ln.strip() for ln in block.group(1).splitlines() if ln.strip())
+        # Inline single-line value
+        inline = re.search(rf"^{field}:\s*(.+)$", fm, re.MULTILINE)
+        if inline:
+            return inline.group(1).strip()
+        # Prettier may wrap a plain value onto indented continuation lines
+        # without a >- marker; fold them into a single space-joined string.
+        wrapped = re.search(
+            rf"^{field}:\s*\n((?:[ \t]+\S[^\n]*\n?)+)",
+            fm,
+            re.MULTILINE,
+        )
+        if wrapped:
+            return " ".join(ln.strip() for ln in wrapped.group(1).splitlines() if ln.strip())
+        return None
+
+    for field in ("description", "readme_description"):
+        val = _read_field(field)
+        if val is not None:
+            result[field] = val
+
+    return result
+
+
+def _short_desc(description: str) -> str:
+    """Shorten 'Use when X, Y, Z ...' to a compact one-clause summary.
+
+    Strategy: strip the 'Use when' prefix, then split at the first colon that
+    is not part of '://' (avoids cutting into URL schemes), if that colon falls
+    in a reasonable range.  Otherwise truncate at a word boundary near 80 chars.
+    """
+    desc = re.sub(r"^[Uu]se when\s+", "", description)
+    desc = re.sub(r"\s+", " ", desc).strip()
+    # Find a natural split point: colon that is not followed by //
+    colon_m = re.search(r":(?!//)", desc)
+    if colon_m and 15 <= colon_m.start() <= 70:
+        desc = desc[: colon_m.start()]
+    elif len(desc) > 80:
+        desc = desc[:80].rsplit(" ", 1)[0] + "..."
+    # Remove dangling open parenthesis from a mid-paren split
+    desc = re.sub(r"\s*\([^)]*$", "", desc)
+    if desc:
+        desc = desc[0].upper() + desc[1:]
+    return desc.rstrip(".,;")
+
+
+# ---------------------------------------------------------------------------
+# Markdown table builder
+# ---------------------------------------------------------------------------
+
+
+def _md_table(headers: list[str], rows: list[list[str]]) -> str:
+    widths = [
+        max(len(h), max((len(r[i]) for r in rows), default=0))
+        for i, h in enumerate(headers)
+    ]
+
+    def fmt(cells: list[str]) -> str:
+        return "| " + " | ".join(c.ljust(widths[i]) for i, c in enumerate(cells)) + " |"
+
+    sep = "| " + " | ".join("-" * w for w in widths) + " |"
+    return "\n".join([fmt(headers), sep, *[fmt(r) for r in rows]])
+
+
+# ---------------------------------------------------------------------------
+# Content generators
+# ---------------------------------------------------------------------------
+
+
+def _plugins_section(marketplace: dict) -> list[str]:
+    parts: list[str] = ["## Plugins\n"]
+
+    for entry in marketplace["plugins"]:
+        name = entry["name"]
+        plugin_dir = ROOT / "plugins" / name
+
+        plugin_info = json.loads(
+            (plugin_dir / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        parts.append(f"### `{name}`\n\n{plugin_info.get('description', '')}\n")
+
+        # Agents
+        agents_dir = plugin_dir / "agents"
+        if agents_dir.is_dir():
+            agent_files = sorted(agents_dir.glob("*.md"))
+            if agent_files:
+                parts.append(
+                    "**Subagents** (invoked automatically or via"
+                    " `Agent(subagent_type=...)`):\n"
+                )
+                rows = []
+                for af in agent_files:
+                    fm = _parse_frontmatter(af)
+                    # readme_description is a short curated summary stored in
+                    # agent frontmatter; fall back to auto-deriving from description
+                    rdesc = fm.get("readme_description") or _short_desc(fm.get("description", ""))
+                    rows.append([f"`{fm.get('name', af.stem)}`", rdesc])
+                parts.append(_md_table(["Subagent", "Purpose"], rows))
+                parts.append("")
+
+        # Skills
+        skills_dir = plugin_dir / "skills"
+        if skills_dir.is_dir():
+            skill_files = sorted(skills_dir.glob("*/SKILL.md"))
+            if skill_files:
+                parts.append("**Skills:**\n")
+                rows = []
+                for sf in skill_files:
+                    fm = _parse_frontmatter(sf)
+                    rows.append([f"`{fm.get('name', sf.parent.name)}`", _short_desc(fm.get("description", ""))])
+                parts.append(_md_table(["Skill", "Description"], rows))
+                parts.append("")
+
+        # MCP servers
+        mcp_path = plugin_dir / ".mcp.json"
+        if mcp_path.exists():
+            mcp = json.loads(mcp_path.read_text(encoding="utf-8"))
+            servers = mcp.get("mcpServers", {})
+            if servers:
+                parts.append(
+                    f"**MCP servers** (configured in `plugins/{name}/.mcp.json`):\n"
+                )
+                rows = []
+                for sname, cfg in servers.items():
+                    cmd = " ".join([cfg.get("command", "")] + cfg.get("args", []))
+                    rows.append([f"`{sname}`", f"`{cmd}`", cfg.get("description", "")])
+                parts.append(_md_table(["Server", "Launch command", "Purpose"], rows))
+                parts.append("")
+
+                if "rucio" in servers and servers["rucio"].get("env"):
+                    parts.extend([
+                        "**Required environment variables for Rucio MCP:**\n",
+                        "```bash",
+                        "export RUCIO_ACCOUNT=yourusername        # required — no default",
+                        'export RUCIO_AUTH_TYPE=x509_proxy        # default; or "oidc" / "userpass"',
+                        "voms-proxy-init --voms atlas             # obtain a valid proxy first",
+                        "```\n",
+                    ])
+
+        parts.append("---\n")
+
+    # Drop trailing separator
+    while parts and parts[-1].strip() in ("---", ""):
+        parts.pop()
+
+    return parts
+
+
+def _layout_section(marketplace: dict) -> list[str]:
+    parts: list[str] = ["## Repository Layout\n"]
+    lines = ["```text", "plugins/"]
+
+    for entry in marketplace["plugins"]:
+        name = entry["name"]
+        plugin_dir = ROOT / "plugins" / name
+        lines.append(f"  {name}/")
+        lines.append("    .claude-plugin/plugin.json")
+        if (plugin_dir / ".mcp.json").exists():
+            lines.append("    .mcp.json")
+        agents_dir = plugin_dir / "agents"
+        if agents_dir.is_dir():
+            n = len(list(agents_dir.glob("*.md")))
+            lines.append(f"    agents/  # {n} subagent{'s' if n != 1 else ''}")
+        skills_dir = plugin_dir / "skills"
+        if skills_dir.is_dir():
+            n = len(list(skills_dir.glob("*/SKILL.md")))
+            lines.append(f"    skills/  # {n} skill{'s' if n != 1 else ''}")
+        if (plugin_dir / "VENDORED-LICENSES.md").exists():
+            lines.append("    VENDORED-LICENSES.md")
+
+    lines.extend([".claude-plugin/marketplace.json", "```"])
+    parts.append("\n".join(lines))
+    return parts
+
+
+def _generate(marketplace: dict) -> str:
+    parts = _plugins_section(marketplace) + [""] + _layout_section(marketplace)
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# README update
+# ---------------------------------------------------------------------------
+
+
+def sync() -> None:
+    """Replace README content between markers."""
+    marketplace = json.loads(MARKETPLACE_JSON.read_text(encoding="utf-8"))
+    new_body = _generate(marketplace)
+
+    text = README.read_text(encoding="utf-8")
+    start = text.find(START_MARKER)
+    end = text.find(END_MARKER)
+    if start == -1 or end == -1:
+        print(f"ERROR: markers {START_MARKER!r} / {END_MARKER!r} not found in {README}", file=sys.stderr)
+        sys.exit(1)
+
+    updated = text[: start + len(START_MARKER)] + "\n\n" + new_body + "\n\n" + text[end:]
+    if updated == text:
+        print("README.md already up to date.")
+        return
+    README.write_text(updated, encoding="utf-8")
+    print(f"Updated {README.relative_to(ROOT)}")
+
+
+def main() -> None:
+    sync()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- xroofit: workspace building, NLL fitting, hypothesis testing, CLs
  limits, discovery significance, fit diagnostics (status/covQual)
- statanalysis: release branches, asetup/Docker/SWAN setup, included
  tools (xRooFit, TRExFitter, HistFitter, cabinetry, quickFit, etc.),
  StatChallenges framework, building from source
- setupatlas: setupATLAS/ALRB entry point, lsetup tool table, asetup
  release patterns, acm package management, rucio/panda/pyami grid
  tools, support contacts; references/asetup.md with full option ref


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Large ATLAS docs added/expanded: setupATLAS/asetup/container options, session save/restore, ACM, StatAnalysis/StatChallenges, xRooFit/advanced refs, quickFit, workspaceCombiner, xmlAnaWSBuilder, PanDA/pathena/prun refs, xcache, lcgenv, art, astyle, atlantis, centralpage, manageTier3SW, cpp-bindings, decaylanguage, pyhf, coffea, uproot, mplhep and README refresh.
* **Chores**
  * CI/config and tooling: new GitHub workflow and Dependabot, pixi tasks, README sync/lint automation, skill-lint/sync scripts, agent readme_description metadata, and MCP server description fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->