### PR TITLE
review: address awkward skill review comments

### DIFF
--- a/plugins/atlas/skills/awkward/SKILL.md
+++ b/plugins/atlas/skills/awkward/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   building event records with ak.zip, filtering nested arrays, computing
   combinatorics (cartesian products or combinations), flattening ragged arrays,
   using argmin/argmax with keepdims, broadcasting per-event weights to
-  per-object, or debugging OptionType/None-padding issues in awkward-array 2.x
+  per-object, or debugging OptionType/None-padding issues in Awkward 2.x
   workflows.
 ---
 
@@ -91,8 +91,8 @@ h.fill(pt=ak.to_numpy(flat_pt), weight=ak.to_numpy(flat_w))
   fixed depth first.
 - **Behavior registration is global**: Call `vector.register_awkward()` once at
   module level; it mutates the global dict.
-- **2.x breaking changes from 1.x**: `ak.ArrayBuilder` → `ak.from_iter`; many
-  behavior patterns changed; do not copy 1.x examples verbatim.
+- **2.x breaking changes from 1.x**: Many top-level functions were renamed or
+  removed; behavior registration changed. Do not copy 1.x examples verbatim.
 
 ## Interop
 

--- a/plugins/atlas/skills/awkward/references/argmin-argmax.md
+++ b/plugins/atlas/skills/awkward/references/argmin-argmax.md
@@ -5,10 +5,10 @@ Use `keepdims=True` to preserve list structure for slicing.
 ```python
 import awkward as ak
 
-array = ak.Array([[7, 5, 7], [], [2], [8, 2]])
-max_values = ak.argmax(array, axis=1, keepdims=True)
+array = ak.Array([[7, 5, 7], [], [2], [8, 2]])  # type='4 * var * int64'
+max_values = ak.argmax(array, axis=1, keepdims=True)  # type='4 * 1 * ?int64'
 print(max_values)               # [[0], [None], [0], [0]]
-print(array[max_values])        # [[7], [None], [2], [8]]
+print(array[max_values])        # [[7], [None], [2], [8]] type='4 * var * ?int64'
 print(ak.firsts(array[max_values]))  # [7, None, 2, 8]
 ```
 
@@ -16,5 +16,5 @@ After slicing with argmin/argmax:
 
 - Use `ak.firsts` to extract the single element per sublist (returns `None` for
   empty events — the safe default).
-- Alternatively, `ak.flatten(..., axis=1)` removes the extra list level, but
-  drops `None` entries silently.
+- Alternatively, `ak.flatten(..., axis=1)` removes the extra list level and
+  returns `[7, None, 2, 8]` of type `4 * ?int64`.

--- a/plugins/atlas/skills/awkward/references/argmin-argmax.md
+++ b/plugins/atlas/skills/awkward/references/argmin-argmax.md
@@ -9,10 +9,12 @@ array = ak.Array([[7, 5, 7], [], [2], [8, 2]])
 max_values = ak.argmax(array, axis=1, keepdims=True)
 print(max_values)               # [[0], [None], [0], [0]]
 print(array[max_values])        # [[7], [None], [2], [8]]
-print(ak.flatten(array[max_values], axis=0))  # [7, None, 2, 8]
+print(ak.firsts(array[max_values]))  # [7, None, 2, 8]
 ```
 
 After slicing with argmin/argmax:
 
-- Use `ak.flatten(..., axis=0)` to remove the extra list level, or
-- Use `ak.firsts` to extract the first element per list.
+- Use `ak.firsts` to extract the single element per sublist (returns `None` for
+  empty events — the safe default).
+- Alternatively, `ak.flatten(..., axis=1)` removes the extra list level, but
+  drops `None` entries silently.

--- a/plugins/atlas/skills/awkward/references/awkward-files.md
+++ b/plugins/atlas/skills/awkward/references/awkward-files.md
@@ -11,6 +11,7 @@
 
 ```python
 import awkward as ak
+from pathlib import Path
 
 # Parquet round-trip
 ak.to_parquet(array, "data.parquet")
@@ -18,10 +19,13 @@ array2 = ak.from_parquet("data.parquet")
 
 # JSON round-trip
 ak.to_json(array, "data.json")
-array3 = ak.from_json("data.json")
+array3 = ak.from_json(Path("data.json"))
 ```
 
 Notes:
 
+- **`from_json` path asymmetry**: `ak.to_json` accepts string paths for output,
+  but `ak.from_json` interprets a bare string as JSON content. Pass a
+  `pathlib.Path` to read from a file.
 - Ensure the format preserves jagged structure.
 - For large datasets, prefer columnar formats like Parquet.

--- a/plugins/atlas/skills/awkward/references/best-practices.md
+++ b/plugins/atlas/skills/awkward/references/best-practices.md
@@ -5,4 +5,6 @@
   calculations.
 - Build an event data model (EDM) with `ak.zip`/records, then add derived fields
   back into the EDM.
-- Avoid `axis=None` for Awkward functions; choose a concrete axis deliberately.
+- `axis=None` is valid for reducers and `ak.flatten`, but it collapses all
+  structure — choose a concrete axis deliberately to preserve per-event
+  semantics.

--- a/plugins/atlas/skills/awkward/references/filtering-aggregation.md
+++ b/plugins/atlas/skills/awkward/references/filtering-aggregation.md
@@ -15,5 +15,6 @@ Notes:
 
 - `ak.max` and `ak.min` exist as reducers; pass `axis=` to control the reduction
   axis. `axis=None` flattens everything and returns a scalar.
-- `axis=None` is valid for all awkward reducers (`ak.sum`, `ak.max`, `ak.min`,
-  `ak.any`, `ak.all`); choose deliberately since it collapses across all events.
+- `axis=None` is valid for all reducers (`ak.sum`, `ak.max`, `ak.min`, `ak.any`,
+  `ak.all`) and `ak.flatten`, but it collapses all structure — choose a concrete
+  axis deliberately to preserve per-event semantics.

--- a/plugins/atlas/skills/awkward/references/flattening.md
+++ b/plugins/atlas/skills/awkward/references/flattening.md
@@ -6,11 +6,30 @@ Always specify `axis` explicitly.
 import awkward as ak
 
 array = ak.Array([[0, 1, 2], [], [3, 4], [5, 6, 7]])
-flat_level1 = ak.flatten(array, axis=1)
-flat_all = ak.flatten(array, axis=None)
+flat_level1 = ak.flatten(array, axis=1)   # [0, 1, 2, 3, 4, 5, 6, 7]
+flat_all = ak.flatten(array, axis=None)   # same here, but drops structure
 ```
 
-Notes:
+## axis=0 special behavior
 
-- `axis=None` completely flattens the array.
-- `axis=1` requires at least one level of nesting.
+`axis=0` does not remove a list level — it only removes `None` values at the top
+level. This is a common source of bugs when flattening argmax/argmin results.
+
+```python
+# axis=0 removes top-level None only
+array = ak.Array([[1.1, 2.2], None, [3.3], [], [4.4]])
+ak.flatten(array, axis=0)   # [[1.1, 2.2], [3.3], [], [4.4]]
+
+# axis=1 removes one list level (and drops None sublists)
+ak.flatten(array, axis=1)   # [1.1, 2.2, 3.3, 4.4]
+```
+
+## Unflattening
+
+`ak.unflatten` rebuilds nested structure from a flat array and a counts array.
+
+```python
+flat = ak.Array([1, 2, 3, 4, 5])
+counts = ak.Array([2, 0, 3])
+ak.unflatten(flat, counts, axis=0)   # [[1, 2], [], [3, 4, 5]]
+```

--- a/plugins/atlas/skills/awkward/references/numpy-interop.md
+++ b/plugins/atlas/skills/awkward/references/numpy-interop.md
@@ -13,7 +13,7 @@ import awkward as ak
 ak.to_numpy(ak.Array([[1, 2], [3, 4]]))   # shape (2, 2)
 
 # Ragged fails — flatten first
-flat = ak.to_numpy(ak.flatten(jets.pt))
+flat = ak.to_numpy(ak.flatten(jets.pt, axis=1))
 
 # Missing values produce a NumPy masked array by default
 ak.to_numpy(ak.Array([1, None, 3]))

--- a/plugins/atlas/skills/awkward/references/numpy-interop.md
+++ b/plugins/atlas/skills/awkward/references/numpy-interop.md
@@ -1,6 +1,31 @@
 # NumPy Interop
 
-- Some NumPy functions dispatch on Awkward arrays when the data are NumPy-like
-  (non-jagged).
-- `np.stack` works when the inputs are effectively 2D.
-- There is no `ak.stack`.
+## Converting to NumPy
+
+`ak.to_numpy(array)` converts to a NumPy array but only succeeds when the data
+are numerical and regular (nested lists have equal lengths in each dimension).
+Ragged arrays raise an error — flatten or pad first.
+
+```python
+import awkward as ak
+
+# Regular works
+ak.to_numpy(ak.Array([[1, 2], [3, 4]]))   # shape (2, 2)
+
+# Ragged fails — flatten first
+flat = ak.to_numpy(ak.flatten(jets.pt))
+
+# Missing values produce a NumPy masked array by default
+ak.to_numpy(ak.Array([1, None, 3]))
+# allow_missing=False raises instead of masking
+```
+
+## NumPy ufuncs
+
+Many NumPy ufuncs dispatch on Awkward arrays automatically:
+
+- `np.sqrt(ak_array)`, `np.log(ak_array)`, etc. work element-wise
+- Python builtins `abs()` works (there is no `ak.abs`)
+- `np.stack` works when inputs are effectively regular
+
+There is no `ak.stack` or `ak.expand_dims`.

--- a/plugins/atlas/skills/awkward/references/pitfalls.md
+++ b/plugins/atlas/skills/awkward/references/pitfalls.md
@@ -1,6 +1,10 @@
 # Pitfalls and Gotchas
 
-- `ak.fill_like(array, value)` requires `value` to be numeric.
-- Use Python's `abs`; there is no `ak.abs`.
+- `ak.full_like(array, value)` requires `value` to be coercible to the array's
+  dtype.
+- Use Python's `abs()`; there is no `ak.abs`.
 - There is no `ak.take`.
 - There is no `ak.expand_dims`.
+- `ak.from_json("file.json")` parses the string as JSON content, not a file
+  path. Use `ak.from_json(Path("file.json"))` to read from a file. `ak.to_json`
+  does not have this asymmetry — it accepts string paths.


### PR DESCRIPTION
Resolves #3.

## Summary

- Fix incorrect API names and examples verified against awkward 2.9.x source (`ak.fill_like` → `ak.full_like`, `ak.flatten(axis=0)` → `ak.firsts`, `ak.from_json` path handling)
- Remove misleading `ArrayBuilder → from_iter` gotcha — both exist in 2.x with different purposes
- Align `axis=None` advice and normalize naming to "Awkward 2.x"
- Expand `flattening.md` (axis=0 semantics, `ak.unflatten`), `numpy-interop.md` (`ak.to_numpy`, masked arrays, ufunc dispatch), and `pitfalls.md` (`from_json` path asymmetry)

## Test plan

- [x] Verify all code examples in reference files run against `awkward >= 2.7`
- [x] Confirm pre-commit passes (`pixi run pre-commit`)
- [x] Confirm check-skills passes (`pixi run check-skills`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified version wording to “Awkward 2.x” and updated breaking-changes guidance.
  * Safer defaults for extracting single elements (use firsts) and updated examples preserving empties.
  * Expanded flatten/unflatten guidance (axis=0 special case, axis=None vs concrete axis) and added unflatten examples.
  * Clarified JSON I/O: when to use Path vs string and asymmetry with to_json.
  * Expanded NumPy interop notes and missing-value guidance; updated full_like warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->