### PR TITLE
review: fsspec-xrootd

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ software orientation.
 
 **MCP servers** (configured in `plugins/atlas/.mcp.json`):
 
-| Server           | Launch command                                                             | Purpose                             |
-| ---------------- | -------------------------------------------------------------------------- | ----------------------------------- |
-| `rucio`          | `pixi exec --spec rucio-mcp sh -c ''"'"'rucio-mcp serve --read-only'"'"''` | Dataset and replica discovery       |
-| `ami`            | `pixi exec --spec ami-mcp sh -c ''"'"'ami-mcp serve'"'"''`                 | AMI metadata (cross-sections, tags) |
-| `atlasopenmagic` | `uvx atlasopenmagic-mcp serve`                                             | ATLAS Open Data catalog             |
+| Server           | Launch command                                                   | Purpose                             |
+| ---------------- | ---------------------------------------------------------------- | ----------------------------------- |
+| `rucio`          | `pixi exec --spec rucio-mcp sh -c 'rucio-mcp serve --read-only'` | Dataset and replica discovery       |
+| `ami`            | `pixi exec --spec ami-mcp sh -c 'ami-mcp serve'`                 | AMI metadata (cross-sections, tags) |
+| `atlasopenmagic` | `uvx atlasopenmagic-mcp serve`                                   | ATLAS Open Data catalog             |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ software orientation.
 
 **MCP servers** (configured in `plugins/atlas/.mcp.json`):
 
-| Server           | Launch command                                                   | Purpose                             |
-| ---------------- | ---------------------------------------------------------------- | ----------------------------------- |
-| `rucio`          | `pixi exec --spec rucio-mcp sh -c 'rucio-mcp serve --read-only'` | Dataset and replica discovery       |
-| `ami`            | `pixi exec --spec ami-mcp sh -c 'ami-mcp serve'`                 | AMI metadata (cross-sections, tags) |
-| `atlasopenmagic` | `uvx atlasopenmagic-mcp serve`                                   | ATLAS Open Data catalog             |
+| Server           | Launch command                                                             | Purpose                             |
+| ---------------- | -------------------------------------------------------------------------- | ----------------------------------- |
+| `rucio`          | `pixi exec --spec rucio-mcp sh -c ''"'"'rucio-mcp serve --read-only'"'"''` | Dataset and replica discovery       |
+| `ami`            | `pixi exec --spec ami-mcp sh -c ''"'"'ami-mcp serve'"'"''`                 | AMI metadata (cross-sections, tags) |
+| `atlasopenmagic` | `uvx atlasopenmagic-mcp serve`                                             | ATLAS Open Data catalog             |
 
 ---
 

--- a/plugins/atlas/skills/fsspec-xrootd/SKILL.md
+++ b/plugins/atlas/skills/fsspec-xrootd/SKILL.md
@@ -3,19 +3,21 @@ name: fsspec-xrootd
 description: >-
   Use when accessing ROOT files on EOS, WLCG grid storage, or any XRootD
   endpoint from Python: mounting an XRootD path as an fsspec filesystem, passing
-  root:// URIs to uproot or awkward, listing remote directories, or
-  troubleshooting XRootD authentication and proxy issues.
+  root:// URIs to uproot or awkward, listing or writing remote directories,
+  multi-site replica access, or troubleshooting XRootD authentication and proxy
+  issues.
 ---
 
 # fsspec-xrootd
 
 ## Overview
 
-fsspec-xrootd registers the `root://` URI scheme with the `fsspec` filesystem
-abstraction. Once installed, any fsspec-aware library (uproot, awkward, dask)
-can read files from EOS (`root://eosatlas.cern.ch/`) or any WLCG grid site
-transparently, as if they were local files. Authentication uses an X.509 proxy
-or token (WLCG Bearer Token), just as the `xrdcp` command-line tool would.
+fsspec-xrootd registers the `root` protocol with the `fsspec` filesystem
+abstraction via an entry-point (`fsspec.specs`) — no explicit import is needed
+once the package is installed. Any fsspec-aware library (uproot, awkward, dask)
+can then read or write files on EOS (`root://eosatlas.cern.ch/`) or any WLCG
+grid site transparently. Authentication uses an X.509 proxy or WLCG Bearer
+Token, just as `xrdcp` would.
 
 ## When to Use
 
@@ -25,35 +27,42 @@ or token (WLCG Bearer Token), just as the `xrdcp` command-line tool would.
 - Listing directory contents on EOS without `eos` or `xrdfs` shell tools
 - Passing `root://` URIs from `rucio list-file-replicas` output directly to
   uproot
+- Accessing files from multiple WLCG grid sites with automatic replica selection
 
 ## Key Concepts
 
-| Concept                | Notes                                                                |
-| ---------------------- | -------------------------------------------------------------------- |
-| `fsspec_xrootd` import | Must be imported before `uproot.open`; registers `root://` scheme    |
-| `root://` URI          | XRootD path: `root://eosatlas.cern.ch//eos/atlas/...`                |
-| Two packages required  | `pip install fsspec-xrootd xrootd` — both must be present            |
-| X.509 proxy            | `voms-proxy-init --voms atlas` before opening remote files           |
-| WLCG Bearer Token      | Alternative to X.509: `export BEARER_TOKEN=$(cat /tmp/bt_u$(id -u))` |
-| `fsspec.filesystem()`  | Direct filesystem object for listing directories                     |
+| Concept               | Notes                                                                   |
+| --------------------- | ----------------------------------------------------------------------- |
+| Auto-registration     | Installed via entry point `fsspec.specs`; no explicit import needed     |
+| `root://` URI         | XRootD path: `root://eosatlas.cern.ch//eos/atlas/...`                   |
+| `[xrootd]` extra      | `pip install "fsspec-xrootd[xrootd]"` — bundles the XRootD C++ bindings |
+| X.509 proxy           | `voms-proxy-init --voms atlas` before opening remote files              |
+| WLCG Bearer Token     | Alternative to X.509: `export BEARER_TOKEN=$(cat /tmp/bt_u$(id -u))`    |
+| `fsspec.filesystem()` | Direct filesystem object; `hostid` is a required parameter              |
+| `locate_all_sources`  | Finds all replicas; defaults to `True`. Set `False` for redirector-only |
+| `valid_sources`       | Allowlist of hostnames to restrict replica selection                    |
+| `timeout`             | XRootD client timeout in seconds; `0` (default) means no timeout        |
 
 Install:
 
 ```bash
-pip install fsspec-xrootd xrootd   # both packages required
+pip install "fsspec-xrootd[xrootd]"    # one package, one extra
+# or
+conda install -c conda-forge fsspec-xrootd
 
-voms-proxy-init --voms atlas        # or set BEARER_TOKEN
+voms-proxy-init --voms atlas             # or set BEARER_TOKEN
 ```
 
 ## Canonical Patterns
 
 ### Transparent uproot access
 
+After installation the `root://` scheme is auto-registered. Explicit
+`import fsspec_xrootd` is harmless but not required.
+
 ```python
 import uproot
-import fsspec_xrootd   # noqa: F401 — registers root:// scheme with fsspec
 
-# uproot uses fsspec automatically for root:// URIs
 with uproot.open("root://eosatlas.cern.ch//eos/atlas/atlascerngroupdisk/..."
                  ":reco") as tree:
     arrays = tree.arrays(["jet_pt", "weight_mc"])
@@ -62,7 +71,7 @@ with uproot.open("root://eosatlas.cern.ch//eos/atlas/atlascerngroupdisk/..."
 ### Iterate over remote files
 
 ```python
-import uproot, fsspec_xrootd  # noqa: F401
+import uproot
 
 for batch in uproot.iterate(
     "root://eosatlas.cern.ch//eos/atlas/path/to/ntuples/*.root:reco",
@@ -100,7 +109,7 @@ pfns = [
     "root://eosatlas.cern.ch//eos/atlas/.../file1.root",
     "root://eosatlas.cern.ch//eos/atlas/.../file2.root",
 ]
-import uproot, fsspec_xrootd  # noqa: F401
+import uproot
 
 arrays = uproot.concatenate(
     [f"{pfn}:reco" for pfn in pfns],
@@ -108,14 +117,73 @@ arrays = uproot.concatenate(
 )
 ```
 
+### Multi-site replica access
+
+When reading via a WLCG redirector, `locate_all_sources` finds every server
+holding the file and picks the best. Use `valid_sources` to restrict which sites
+are tried (entries must be bare hostnames, no port).
+
+```python
+import fsspec
+
+fs = fsspec.filesystem(
+    "root",
+    hostid="cms-xrd-global.cern.ch",     # WLCG global redirector
+    locate_all_sources=True,
+    valid_sources=["cmsxrootd-site1.fnal.gov", "xrootd.unl.edu"],
+)
+with fs.open("/store/mc/path/to/file.root", "rb") as f:
+    ...
+```
+
+### Write a file to EOS
+
+```python
+import fsspec
+
+fs = fsspec.filesystem("root", hostid="eosatlas.cern.ch")
+with fs.open("/eos/atlas/user/m/myuser/output/result.txt", "wb") as f:
+    f.write(b"result data")
+```
+
+### Query server checksum
+
+```python
+import fsspec
+
+fs = fsspec.filesystem("root", hostid="eosatlas.cern.ch")
+algorithm, value = fs.checksum("/eos/atlas/path/file.root")
+print(f"{algorithm}: {value}")   # e.g. "adler32: 1a2b3c4d"
+```
+
+### Storage options for performance tuning
+
+```python
+import fsspec
+
+fs = fsspec.filesystem(
+    "root",
+    hostid="eosatlas.cern.ch",
+    timeout=60,                    # seconds; 0 = no timeout (default)
+    filehandle_cache_size=512,     # max open file handles cached (default 256)
+    filehandle_cache_ttl=60,       # seconds before cached handles expire (default 30)
+)
+```
+
 ## Gotchas
 
-- **Two packages required**: `fsspec-xrootd` (fsspec plugin) and `xrootd`
-  (Python bindings for the XRootD C++ library). Both must be installed.
-- **`import fsspec_xrootd` must happen before `uproot.open`**: the import
-  registers the `root://` scheme handler.
+- **`[xrootd]` extra is required**: Install as
+  `pip install "fsspec-xrootd[xrootd]"`. The bare `pip install fsspec-xrootd`
+  omits the XRootD C++ bindings. If you see
+  `ModuleNotFoundError: No module named 'XRootD'`, re-install with the extra.
+- **No explicit import needed**: `root://` is auto-registered via the fsspec
+  entry-point (`fsspec.specs`) when the package is installed. Explicit
+  `import fsspec_xrootd` is safe but unnecessary in normal installed usage.
+- **`valid_sources` hostnames have no port**: entries like
+  `cmsxrootd-site1.fnal.gov` are bare domain names; the port is stripped
+  automatically from XRootD replies.
 - **Proxy lifetime**: Grid proxies expire after 12–24 hours; VOMS-extended
-  proxies after 96 hours. Running long coffea jobs overnight may hit proxy
+  proxies after 96 hours. Long coffea jobs running overnight may hit proxy
   expiry.
 - **EOS quota and rate limits**: EOS has per-user open-file and bandwidth
   limits; for large-scale processing use Rucio to stage files to a local
@@ -124,18 +192,19 @@ arrays = uproot.concatenate(
   `voms-proxy-info --all` and `voms-proxy-init --voms atlas`.
 - **`[ERROR] No servers are available`**: wrong hostname or endpoint down —
   check with `xrdfs root://eosatlas.cern.ch/ ping`.
-- **`Module 'XRootD' not found`**: `xrootd` Python bindings not installed —
-  `pip install xrootd`.
 - **Slow reads**: reading many small chunks over WAN — increase uproot
   `step_size` or use an EOS-local analysis facility.
 - **`FileNotFoundError` on valid path**: trailing slash or case sensitivity —
   verify with `fs.ls()`.
+- **Linux only**: fsspec-xrootd is only tested on Linux (XRootD C++ library
+  constraint).
 - **ATLAS energy/momentum values are in MeV**: fields like `jet_pt`, `met_met`
   come from ATLAS NTuples in MeV — divide by 1000 before GeV-scale comparisons.
 
 ## Interop
 
-- **uproot**: `root://` URIs work transparently after `import fsspec_xrootd`.
+- **uproot**: `root://` URIs work transparently after installation via the entry
+  point; no additional import required.
 - **Rucio / atlas-data-explorer**: Obtain PFNs from Rucio replicas; pass
   directly to uproot via fsspec-xrootd.
 - **coffea**: coffea's dask executor works with `root://` file lists via
@@ -143,4 +212,4 @@ arrays = uproot.concatenate(
 
 ## Docs
 
-https://coffeateam.github.io/fsspec-xrootd/
+https://scikit-hep.org/fsspec-xrootd/


### PR DESCRIPTION
- Fix install command: pip install "fsspec-xrootd[xrootd]" (one package
  with optional extra, not two separate packages)
- Remove incorrect "must import before uproot.open" claim; package
  auto-registers via fsspec entry-point (fsspec.specs)
- Fix docs URL: scikit-hep.org/fsspec-xrootd (was coffeateam.github.io)
- Add patterns: multi-site replica access, write to EOS, checksum query,
  storage options (timeout, filehandle_cache_size, filehandle_cache_ttl)
- Add conda-forge install option
- Add Linux-only and valid_sources hostname-format gotchas
- Sync README

Assisted-by: Claude (Anthropic)

See #10.