### PR TITLE
fix(atlas): remove shell quoting from .mcp.json -c arguments

### DIFF
--- a/plugins/atlas/.mcp.json
+++ b/plugins/atlas/.mcp.json
@@ -9,7 +9,7 @@
         "rucio-mcp",
         "sh",
         "-c",
-        "'rucio-mcp serve --read-only'"
+        "rucio-mcp serve --read-only"
       ],
       "env": {
         "RUCIO_ACCOUNT": "${RUCIO_ACCOUNT}"
@@ -18,7 +18,7 @@
     "ami": {
       "description": "AMI metadata (cross-sections, tags)",
       "command": "pixi",
-      "args": ["exec", "--spec", "ami-mcp", "sh", "-c", "'ami-mcp serve'"]
+      "args": ["exec", "--spec", "ami-mcp", "sh", "-c", "ami-mcp serve"]
     },
     "atlasopenmagic": {
       "description": "ATLAS Open Data catalog",


### PR DESCRIPTION
The -c argument values had embedded single quotes which caused
sync_skills.py shlex.join to double-escape them, corrupting the
MCP server table in README.md on every sync run. The shell quotes
are unnecessary since the arg is passed directly to sh via execve.

Assisted-by: Claude (Anthropic)
