### PR TITLE
review: cabinetry

### DIFF
--- a/plugins/atlas/skills/cabinetry/SKILL.md
+++ b/plugins/atlas/skills/cabinetry/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   cabinetry config file, building histogram templates from ROOT NTuples,
   constructing a pyhf workspace, running a profile likelihood fit, visualising
   pre/post-fit data-MC comparisons, producing pull plots and NP rankings, or
-  computing CLs exclusion limits via cabinetry's high-level API.
+  computing CLs exclusion limits or discovery significance via cabinetry's
+  high-level API.
 ---
 
 # cabinetry
@@ -32,16 +33,24 @@ NTuples (ROOT) → cabinetry templates → pyhf workspace → fit → plots
 
 1. Write a config file (YAML or Python dict)
 2. `cabinetry.templates.build(config)` — fills histograms from NTuples
-3. `cabinetry.workspace.build(config)` — creates HistFactory JSON
-4. `cabinetry.fit.fit(model, data)` — profile likelihood fit
-5. `cabinetry.visualize.*` — plots
+3. `cabinetry.templates.postprocess(config)` — applies smoothing /
+   symmetrization
+4. `cabinetry.workspace.build(config)` — creates HistFactory JSON
+5. `cabinetry.fit.fit(model, data)` — profile likelihood fit
+6. `cabinetry.visualize.*` — plots
 
 ### Config Structure
 
+`General`, `Regions`, `Samples`, and `NormFactors` are all required top-level
+blocks. `Systematics` is optional. NormFactors live in their own block — they
+are **not** nested inside Samples.
+
 ```yaml
 General:
+  Measurement: "my_analysis"
   HistogramFolder: "histograms/"
   InputPath: "ntuples/{SamplePath}"
+  POI: "mu_sig"
 
 Regions:
   - Name: "SR"
@@ -55,13 +64,22 @@ Regions:
 
 Samples:
   - Name: "Data"
-    Data: true
+    Tree: "nominal"
     SamplePath: "data/*.root"
+    Data: true
   - Name: "Signal"
+    Tree: "nominal"
     SamplePath: "signal/signal.root"
-    NormFactor: "mu_sig"
   - Name: "ttbar"
+    Tree: "nominal"
     SamplePath: "ttbar/ttbar.root"
+    Weight: "weight"
+
+NormFactors:
+  - Name: "mu_sig"
+    Samples: "Signal"
+    Nominal: 1
+    Bounds: [0, 10]
 
 Systematics:
   - Name: "JES"
@@ -72,9 +90,11 @@ Systematics:
     Type: NormPlusShape
     Samples: "ttbar"
   - Name: "Lumi"
-    Value: 0.015
+    Up:
+      Normalization: 0.015
+    Down:
+      Normalization: -0.015
     Type: Normalization
-    Samples: ["Signal", "ttbar"]
 ```
 
 ## Canonical Patterns
@@ -84,36 +104,53 @@ Systematics:
 ```python
 import cabinetry
 
+cabinetry.set_logging()  # optional: verbose logging
+
 config = cabinetry.configuration.load("config.yaml")
 cabinetry.configuration.print_overview(config)
 
-# Build histogram templates from NTuples
+# Build and post-process histogram templates from NTuples
 cabinetry.templates.build(config)
+cabinetry.templates.postprocess(config)
 
 # Construct pyhf workspace
 workspace = cabinetry.workspace.build(config)
 cabinetry.workspace.save(workspace, "workspace.json")
 
-# Build model and fit
-model, data = cabinetry.model_utils.model_and_data(workspace)
+# Reload workspace, build model and fit
+ws = cabinetry.workspace.load("workspace.json")
+model, data = cabinetry.model_utils.model_and_data(ws)
 fit_results = cabinetry.fit.fit(model, data)
 ```
 
 **Visualisation**:
 
 ```python
-# Pre-fit data/MC
-cabinetry.visualize.data_mc(config, figure_folder="figures/prefit/")
+# Get pre- and post-fit model predictions
+prediction_prefit = cabinetry.model_utils.prediction(model)
+prediction_postfit = cabinetry.model_utils.prediction(model, fit_results=fit_results)
 
-# Post-fit data/MC
-cabinetry.visualize.data_mc(config, figure_folder="figures/postfit/", fit_results=fit_results)
+# Pre-fit and post-fit data/MC comparison plots
+cabinetry.visualize.data_mc(prediction_prefit, data, config=config)
+cabinetry.visualize.data_mc(prediction_postfit, data, config=config)
 
-# NP pulls
+# Yield table (post-fit)
+cabinetry.tabulate.yields(prediction_postfit, data)
+
+# NP pulls and correlation matrix
 cabinetry.visualize.pulls(fit_results, figure_folder="figures/")
+cabinetry.visualize.correlation_matrix(fit_results, figure_folder="figures/")
 
 # NP ranking (impact on POI)
 ranking_results = cabinetry.fit.ranking(model, data, fit_results=fit_results)
 cabinetry.visualize.ranking(ranking_results, figure_folder="figures/")
+```
+
+**Likelihood scan**:
+
+```python
+scan_results = cabinetry.fit.scan(model, data, "mu_sig")
+cabinetry.visualize.scan(scan_results, figure_folder="figures/")
 ```
 
 **CLs upper limit**:
@@ -121,7 +158,18 @@ cabinetry.visualize.ranking(ranking_results, figure_folder="figures/")
 ```python
 limit_results = cabinetry.fit.limit(model, data)
 print(f"Observed limit: {limit_results.observed_limit:.2f}")
-print(f"Expected limit: {limit_results.expected_limit[2]:.2f}")  # median
+# expected_limit is a 5-element array: [-2s, -1s, median, +1s, +2s]
+print(f"Expected limit: {limit_results.expected_limit[2]:.2f}")
+
+cabinetry.visualize.limit(limit_results, figure_folder="figures/")
+```
+
+**Discovery significance**:
+
+```python
+sig_results = cabinetry.fit.significance(model, data)
+print(f"Observed significance: {sig_results.observed_significance:.2f} sigma")
+print(f"Expected significance: {sig_results.expected_significance:.2f} sigma")
 ```
 
 **Load a pre-built workspace directly** (skip template building):
@@ -136,15 +184,18 @@ fit_results = cabinetry.fit.fit(model, data)
 
 ### Config Tips
 
-- `NormFactor` on a sample inserts a free `normfactor` modifier — use for signal
-  μ and CR-driven backgrounds
+- `NormFactors` is a top-level config block — each entry has `Name`, `Samples`,
+  `Nominal`, and optionally `Bounds`. Use for signal μ and CR-driven
+  backgrounds.
 - `Type: NormPlusShape` creates separate norm and shape modifiers — correct for
   most experimental systematics
-- `Type: Normalization` (with `Value`) creates a `normsys` modifier — for
-  luminosity and cross-section uncertainties
-- Samples not listed under a Systematic get that systematic applied with zero
-  effect — fine for backgrounds with no uncertainty
-- `AddStatError: true` (global option) adds Barlow-Beeston staterror to all bins
+- `Type: Normalization` uses `Up.Normalization` / `Down.Normalization` (a
+  fractional value, e.g. `0.015` for 1.5%) — for luminosity and cross-section
+  uncertainties
+- `Down: {Symmetrize: true}` mirrors the Up variation, useful when only one
+  variation is available
+- Stat errors (Barlow-Beeston) are included automatically; use
+  `DisableStaterror: true` on a sample to suppress them
 
 ## Gotchas
 
@@ -156,8 +207,11 @@ fit_results = cabinetry.fit.fit(model, data)
   `SamplePath` glob patterns
 - **Pre-existing histograms**: If `HistogramFolder` has old files, `build()`
   will use them. Delete the folder to force a rebuild.
-- **Symmetric systematics**: If only `Up` is specified, cabinetry mirrors it for
-  `Down` automatically
+- **`postprocess()` is required**: skipping it means smoothing and
+  symmetrization from the config are never applied before workspace construction
+- **`data_mc` takes a ModelPrediction, not a config**: call
+  `cabinetry.model_utils.prediction(model)` first, then pass it as the first
+  argument along with `data`
 
 ## Interop
 


### PR DESCRIPTION
## Summary

- Fix `visualize.data_mc` signature: takes `ModelPrediction` + `data`, not `config`
- Fix config schema: `NormFactors` is a required top-level block, not nested in `Samples`; fix `Systematics` normalization to use `Up/Down.Normalization` instead of `Value`; add required `General.Measurement` and `Tree` keys; remove nonexistent `AddStatError` global option
- Add missing `templates.postprocess()` step and `workspace.load()`, plus coverage of `tabulate.yields()`, `fit.scan()`, `fit.significance()`, `visualize.correlation_matrix()`, `visualize.scan()`, `visualize.limit()`, and `cabinetry.set_logging()`

See #4