### PR TITLE
Enhance SKILL.md for pylhe with HDF5 support

### DIFF
--- a/plugins/atlas/skills/pylhe/SKILL.md
+++ b/plugins/atlas/skills/pylhe/SKILL.md
@@ -65,6 +65,17 @@ to identify a file.
 | `LHEInit.generators`                       | List of `LHEGenerator` (generator metadata)                |
 | `LHEFile.header.initrwgt`                  | `LHEInitRWGT`: reweighting-group definitions (file header) |
 | `pylhe.to_awkward(events)`                 | Converts event iterator to an awkward array                |
+| `pylhe.DEFAULT_FORMAT`                     | XML, RWGT weights, plain                                   |
+| `pylhe.GZ_FORMAT`                          | XML, RWGT weights, gzip compression                        |
+| `pylhe.RWGT_FORMAT`                        | XML, RWGT weights block, plain                             |
+| `pylhe.WEIGHTS_FORMAT`                     | XML, WEIGHTS weights block, plain                          |
+| `pylhe.RWGT_GZ_FORMAT`                     | XML, RWGT weights block, gzip compression                  |
+| `pylhe.WEIGHTS_GZ_FORMAT`                  | XML, WEIGHTS weights block,  gzip compression              |
+| `pylhe.NO_WEIGHTS_FORMAT`                  | XML, no weights block, plain                               |
+| `pylhe.HDF5_FORMAT`                        | Output format for HDF5-based LHEH5 files                   |
+| `pylhe.HDF5_GZ_FORMAT`                     | LHEH5, gzip-compressed, shuffled HDF5 datasets             |
+
+
 
 ## Canonical Patterns
 
@@ -198,6 +209,10 @@ event.graph.render("event_topology", format="pdf", view=True, cleanup=True)
   materialise into a list, or wrap with `list()`.
 - **Status codes vary by generator**: v1-era generators sometimes use status=0
   for all particles; v3 files follow the standard (-1/+1/+2).
+- `write()`, `tolhe()`, and `tofile()` now use format objects (`LHEXMLFormat` /
+  `LHEHDF5Format`) and `LHEWeightFormat` instead of the old `rwgt`, `weights`,
+  and `gz` booleans.
+
 
 ## Interop
 

--- a/plugins/atlas/skills/pylhe/SKILL.md
+++ b/plugins/atlas/skills/pylhe/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: pylhe
 description: >-
-  Use when reading or writing Les Houches Event (LHE) files in Python: reading
+  Use when reading or writing Les Houches Event XML (LHE) or HDF5 (LHEH5) files in Python: reading
   parton-level events from MadGraph, Powheg, Sherpa, Pythia, or Whizard
   generators, iterating over initial- and final-state parton four-vectors,
   accessing event weights and scale/PDF reweighting blocks, counting events
   efficiently, writing modified LHE files back to disk, visualising event
   topologies with graphviz, or converting events to awkward arrays for
   vectorized analysis. Also use when the user mentions `LHEFile`, `LHEEvent`,
-  `LHEParticle`, or parsing `.lhe` / `.lhe.gz` files.
+  `LHEParticle`, or parsing `.lhe` / `.lhe.gz` / `lhe.hdf5` / `.lheh5` files.
 ---
 
 # pylhe
@@ -23,6 +23,9 @@ an iterable of events as typed dataclass attributes. The older module-level read
 functions (`read_lhe`, `read_lhe_init`, `read_num_events`,
 `read_lhe_with_attributes`, `read_lhe_file`) were **removed** in v1.0.0 — they
 no longer exist. `to_awkward` is still a module-level function and is current.
+Since v2.0.0 also HDF5 files in the LHEH5 format are supported for reading and 
+writing through `LHEFile`. Similar to gzip magic bytes hdf5 magic bytes are used 
+to identify a file.
 
 ## When to Use
 
@@ -34,31 +37,33 @@ no longer exist. `to_awkward` is still a module-level function and is current.
 - Counting events without loading the whole file into memory
 - Writing modified or synthetic LHE files
 - Visualising parton-level decay topologies interactively in a notebook
+- Conversion from LHEH5 to LHE XML
 
 ## Key Concepts
 
-| Concept                              | Notes                                                      |
-| ------------------------------------ | ---------------------------------------------------------- |
-| `LHEFile.fromfile(path)`             | Load file; returns `LHEFile` (lazy generator)              |
-| `LHEFile.frombuffer(fileobj)`        | Same, from an already-open file object                     |
-| `LHEFile.fromstring(text)`           | Parse an LHE string directly                               |
-| `LHEFile.count_events(path)`         | Counts events without loading them                         |
-| `lhef.init`                          | `LHEInit` dataclass (beam info, xsec, groups)              |
-| `lhef.events`                        | Iterator of `LHEEvent` objects                             |
-| `lhef.tofile(path)` / `lhef.tolhe()` | Write back to file or to a string                          |
-| `LHEEvent.eventinfo`                 | `LHEEventInfo` (nparticles, pid, weight, …)                |
-| `LHEEvent.particles`                 | List of `LHEParticle` objects                              |
-| `LHEEvent.weights`                   | Dict `{weight_id: float}` (needs `with_attributes=True`)   |
-| `LHEEvent.graph`                     | `graphviz.Digraph` of the event topology                   |
-| `LHEParticle.status`                 | -1 = incoming, +1 = outgoing, +2 = intermediate            |
-| `LHEParticle.id`                     | PDG ID                                                     |
-| `LHEParticle.px/py/pz/e/m`           | Four-momentum + mass (GeV)                                 |
-| `LHEParticle.event`                  | Deprecated back-ref; use `LHEEvent.mothers(particle)`      |
-| `LHEInit.initInfo`                   | `LHEInitInfo` (beam PDG IDs, energies, PDFs)               |
-| `LHEInit.procInfo`                   | List of `LHEProcInfo` (xSection, error, …)                 |
-| `LHEInit.generators`                 | List of `LHEGenerator` (generator metadata)                |
-| `LHEFile.header.initrwgt`            | `LHEInitRWGT`: reweighting-group definitions (file header) |
-| `pylhe.to_awkward(events)`           | Converts event iterator to an awkward array                |
+| Concept                                    | Notes                                                      |
+| ------------------------------------------ | ---------------------------------------------------------- |
+| `LHEFile.fromfile(path)`                   | Load file; returns `LHEFile` (lazy generator)              |
+| `LHEFile.frombuffer(fileobj)`              | Same, from an already-open file object                     |
+| `LHEFile.fromstring(text)`                 | Parse an LHE string directly                               |
+| `LHEFile.count_events(path)`               | Counts events without loading them                         |
+| `LHEFile.init`                             | `LHEInit` dataclass (beam info, xsec, groups)              |
+| `LHEFile.events`                           | Iterator of `LHEEvent` objects                             |
+| `LHEFile.tofile(path)`                     | Write to a file                                            |
+| `LHEFile.tolhe()`                          | Return a string                                            |
+| `LHEEvent.eventinfo`                       | `LHEEventInfo` (nparticles, pid, weight, …)                |
+| `LHEEvent.particles`                       | List of `LHEParticle` objects                              |
+| `LHEEvent.mothers(particle)`               | Get mothers of a particle in this event                    |
+| `LHEEvent.weights`                         | Dict `{weight_id: float}` (needs `with_attributes=True`)   |
+| `LHEEvent.graph`                           | `graphviz.Digraph` of the event topology                   |
+| `LHEParticle.status`                       | -1 = incoming, +1 = outgoing, +2 = intermediate            |
+| `LHEParticle.id`                           | PDG ID                                                     |
+| `LHEParticle.px/py/pz/e/m`                 | Four-momentum + mass (GeV)                                 |
+| `LHEInit.initInfo`                         | `LHEInitInfo` (beam PDG IDs, energies, PDFs)               |
+| `LHEInit.procInfo`                         | List of `LHEProcInfo` (xSection, error, …)                 |
+| `LHEInit.generators`                       | List of `LHEGenerator` (generator metadata)                |
+| `LHEFile.header.initrwgt`                  | `LHEInitRWGT`: reweighting-group definitions (file header) |
+| `pylhe.to_awkward(events)`                 | Converts event iterator to an awkward array                |
 
 ## Canonical Patterns
 
@@ -179,8 +184,7 @@ event.graph.render("event_topology", format="pdf", view=True, cleanup=True)
   `pylhe.read_lhe_file()` were removed in v1.0.0 and now raise `AttributeError`.
   Use `LHEFile.fromfile(path).events`, `LHEFile.fromfile(path).init`, and
   `LHEFile.count_events(path)` respectively.
-- **`LHEParticle.event` is deprecated**: the per-particle back-reference emits a
-  `DeprecationWarning`; use `LHEEvent.mothers(particle)` instead.
+- **`LHEParticle.event` is removed**: use `LHEEvent.mothers(particle)` instead.
 - **`with_attributes=True`** (the default) is required to populate
   `event.weights`; pass `with_attributes=False` and event weights will be empty
   dicts.

--- a/plugins/atlas/skills/pylhe/SKILL.md
+++ b/plugins/atlas/skills/pylhe/SKILL.md
@@ -55,6 +55,7 @@ to identify a file.
 | `LHEEvent.particles`                       | List of `LHEParticle` objects                              |
 | `LHEEvent.mothers(particle)`               | Get mothers of a particle in this event                    |
 | `LHEEvent.weights`                         | Dict `{weight_id: float}` (needs `with_attributes=True`)   |
+| `LHEEvent.scales`                          | Dict `{scale_id: float}` (needs `with_attributes=True`)    |
 | `LHEEvent.graph`                           | `graphviz.Digraph` of the event topology                   |
 | `LHEParticle.status`                       | -1 = incoming, +1 = outgoing, +2 = intermediate            |
 | `LHEParticle.id`                           | PDG ID                                                     |


### PR DESCRIPTION
Updated the description to include support for HDF5 files and clarified deprecated features.

Note: I have not tried this SKILL.md since I dont use it. Just updated some texts.

Cheers,
APN

Closes: https://github.com/usatlas/marketplace/issues/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded `pylhe` guidance for reading, writing, and parsing LHEH5/HDF5 files.
  * Documented LHEH5 support, format detection, and conversion to LHE XML.
  * Updated API guidance for current `LHEFile`, `LHEEvent`, and `LHEParticle` usage.
  * Clarified supported format constants and the removal of `LHEParticle.event`.
  * Updated examples and notes for format-object-based writing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->